### PR TITLE
LTerm_geom: add col2

### DIFF
--- a/src/lTerm_geom.mli
+++ b/src/lTerm_geom.mli
@@ -44,7 +44,7 @@ type rect = {
 val row1 : rect -> int
 val col1 : rect -> int
 val row2 : rect -> int
-val row2 : rect -> int
+val col2 : rect -> int
 
 val size_of_rect : rect -> size
   (** Returns the size of a rectangle. *)


### PR DESCRIPTION
Replaces the second `row2` declaration with `col2`.
