### PR TITLE
LTerm_read_line: Allow to define the index with set_completion.

### DIFF
--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -233,10 +233,16 @@ object(self)
   (* Save for when setting the macro counter. *)
   val mutable save = (0, Zed_rope.empty)
 
-  method set_completion start words =
+  method set_completion ?(index=0) start words =
+    let len = List.length words in
+    if index < 0 || index > len - 1 then raise (Invalid_argument
+          "LTerm_read_line.set_completion: index out of bounds compared to words."
+      ) ;
+    let step = React.Step.create () in
     completion_start <- start;
-    set_completion_index 0;
-    set_completion_words words
+    set_completion_index ~step index ;
+    set_completion_words ~step words ;
+    React.Step.execute step
 
   initializer
     completion_event <- (
@@ -521,7 +527,7 @@ class virtual ['a] abstract = object
   method virtual input_next : Zed_rope.t
   method virtual completion_words : (Zed_utf8.t * Zed_utf8.t) list signal
   method virtual completion_index : int signal
-  method virtual set_completion : int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
+  method virtual set_completion : ?index:int -> int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
   method virtual completion : unit
   method virtual complete : unit
   method virtual show_box : bool

--- a/src/lTerm_read_line.mli
+++ b/src/lTerm_read_line.mli
@@ -186,11 +186,12 @@ class virtual ['a] engine : ?history : history -> ?clipboard : Zed_edit.clipboar
   method completion_index : int signal
     (** The position in the completion bar. *)
 
-  method set_completion : int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
-    (** [set_completion index words] sets the current
-        completions. [index] is the index of the beginning of the word
+  method set_completion : ?index:int -> int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
+    (** [set_completion ?index start words] sets the current
+        completions. [start] is the position of the beginning of the word
         being completed and [words] is the list of possible
-        completions with their suffixes. The result is made available
+        completions with their suffixes. [index] is the position in the completion
+        bar, default to [0]. The result is made available
         through the {!completion_words} signal. *)
 
   method completion : unit
@@ -221,7 +222,7 @@ class virtual ['a] abstract : object
   method virtual input_next : Zed_rope.t
   method virtual completion_words : (Zed_utf8.t * Zed_utf8.t) list signal
   method virtual completion_index : int signal
-  method virtual set_completion : int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
+  method virtual set_completion : ?index:int -> int -> (Zed_utf8.t * Zed_utf8.t) list -> unit
   method virtual completion : unit
   method virtual complete : unit
   method virtual show_box : bool


### PR DESCRIPTION
This allows to set the index of completion when setting the completion. It allows to "focus" a specific completion directly (which I need for [this](https://github.com/OCamlPro/ocp-index/pull/43)).
