### PR TITLE
Remove use of deprecated Lwt_sys.windows

### DIFF
--- a/src/lTerm.ml
+++ b/src/lTerm.ml
@@ -167,7 +167,7 @@ let () = CharEncoding.alias "CP65001" "UTF-8"
 
 let empty_stream = Lwt_stream.from (fun () -> return None)
 
-let create ?(windows=Lwt_sys.windows) ?(model=default_model) ?incoming_encoding ?outgoing_encoding incoming_fd incoming_channel outgoing_fd outgoing_channel =
+let create ?(windows=Sys.win32) ?(model=default_model) ?incoming_encoding ?outgoing_encoding incoming_fd incoming_channel outgoing_fd outgoing_channel =
   Lwt.catch (fun () ->
     (* Colors stuff. *)
     let colors = if windows then 16 else colors_of_term model in

--- a/src/lTerm.mli
+++ b/src/lTerm.mli
@@ -32,7 +32,7 @@ val create :
       [output_fd] and [output_channel] for outputs.
 
       - [windows] indicates whether the terminal is a windows console
-      (not mintty, rxvt, ...). It defaults to [Lwt_sys.windows].
+      (not mintty, rxvt, ...). It defaults to [Sys.win32].
 
       - [model] is the type of the terminal, such as "rxvt" or
       "xterm". It defaults to the contents of the "TERM" environment

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -1065,7 +1065,7 @@ object(self)
         Zed_macro.cancel self#macro;
         self#exec (Zed_macro.contents macro @ actions)
     | Suspend :: actions ->
-        if Lwt_sys.windows then
+        if Sys.win32 then
           self#exec actions
         else begin
           let is_visible = visible in

--- a/src/lTerm_resources.ml
+++ b/src/lTerm_resources.ml
@@ -16,7 +16,7 @@ let home =
     try
       (Unix.getpwuid (Unix.getuid ())).Unix.pw_dir
     with Unix.Unix_error _ | Not_found ->
-      if Lwt_sys.windows then
+      if Sys.win32 then
         try
           Sys.getenv "AppData"
         with Not_found ->


### PR DESCRIPTION
See also https://github.com/ocsigen/lwt/pull/107.

This raises the OCaml dependency to 4.01.
