### PR TITLE
Switch from camomile to uu*

### DIFF
--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -14,7 +14,6 @@ depends: [
   "lwt_log"
   "react"
   "zed"   {>= "2.0" & < "3.0"}
-  "camomile" {>= "0.8.6"}
   "lwt_react"
   "dune" {build & >= "1.0.0"}
 ]

--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -14,8 +14,10 @@ depends: [
   "lwt_log"
   "react"
   "zed"   {>= "2.0" & < "3.0"}
+  "camomile" {>= "0.8.6"}
   "lwt_react"
   "dune" {build & >= "1.0.0"}
+  "uchar" { ocaml-version < "4.03" }
 ]
 build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 available: [ ocaml-version >= "4.02.3" ]

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name lambda_term)
   (public_name lambda-term)
   (wrapped false)
-  (libraries lwt lwt.unix lwt_react zed lwt_log)
+  (libraries lwt lwt.unix lwt_react zed lwt_log camomile)
   (flags (:standard -safe-string))
   (synopsis "Cross-platform library for terminal manipulation")
   (c_names lTerm_term_stubs lTerm_unix_stubs lTerm_windows_stubs)

--- a/src/lTerm.ml
+++ b/src/lTerm.ml
@@ -7,6 +7,7 @@
  * This file is a part of Lambda-Term.
  *)
 
+open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_geom
 
@@ -80,8 +81,8 @@ type t = {
   mutable size : size;
   (* The current size of the terminal. *)
 
-  incoming_encoding : Uutf.decoder_encoding;
-  outgoing_encoding : Uutf.encoding;
+  incoming_encoding : CharEncoding.t;
+  outgoing_encoding : CharEncoding.t;
   (* Characters encodings. *)
 
   outgoing_is_utf8 : bool;
@@ -156,16 +157,14 @@ let colors_of_term = function
 
 exception No_such_encoding of string
 
-let decoder_encoding_of_string s =
-  match Uutf.encoding_of_string s, s with
-  | Some s, _ -> s
-  | None, "CP65001" -> `UTF_8
-  | _ -> raise (No_such_encoding s)
+let char_encoding_of_name name =
+  try
+    CharEncoding.of_name name
+  with Not_found ->
+    raise (No_such_encoding name)
 
-let encoding_of_string s =
-  match decoder_encoding_of_string s with
-  | #Uutf.encoding as e -> e
-  | _ -> raise (No_such_encoding s)
+(* UTF-8 on windows. *)
+let () = CharEncoding.alias "CP65001" "UTF-8"
 
 let empty_stream = Lwt_stream.from (fun () -> return None)
 
@@ -196,29 +195,25 @@ let create
     in
     (* Encodings. *)
     let incoming_encoding =
-      match incoming_encoding with
-        | Some name ->
-            name
-        | None ->
-            let name =
-              if windows then
-                Printf.sprintf "CP%d" (LTerm_windows.get_console_cp ())
-              else
-                LTerm_unix.system_encoding
-            in
-            decoder_encoding_of_string name
+      char_encoding_of_name
+        (match incoming_encoding with
+           | Some name ->
+               name
+           | None ->
+               if windows then
+                 Printf.sprintf "CP%d" (LTerm_windows.get_console_cp ())
+               else
+                 LTerm_unix.system_encoding)
     and outgoing_encoding =
-      match outgoing_encoding with
-        | Some name ->
-            name
-        | None ->
-            let name =
-              if windows then
-                Printf.sprintf "CP%d" (LTerm_windows.get_console_output_cp ())
-              else
-                LTerm_unix.system_encoding
-            in
-            encoding_of_string name in
+      char_encoding_of_name
+        (match outgoing_encoding with
+           | Some name ->
+               name
+           | None ->
+               if windows then
+                 Printf.sprintf "CP%d" (LTerm_windows.get_console_output_cp ())
+               else
+                 LTerm_unix.system_encoding) in
     (* Check if fds are ttys. *)
     Lwt_unix.isatty incoming_fd >>= fun incoming_is_a_tty ->
     Lwt_unix.isatty outgoing_fd >>= fun outgoing_is_a_tty ->
@@ -239,7 +234,7 @@ let create
       read_event = false;
       incoming_encoding;
       outgoing_encoding;
-      outgoing_is_utf8 = outgoing_encoding = `UTF_8;
+      outgoing_is_utf8 = CharEncoding.name_of outgoing_encoding = "UTF-8";
       notify = Lwt_condition.create ();
       event = E.never;
       incoming_is_a_tty;
@@ -316,6 +311,12 @@ let set_size _ _ = Lwt.fail (Failure "LTerm.set_size is deprecated")
    | Events                                                          |
    +-----------------------------------------------------------------+ *)
 
+class output_single (cell : UChar.t option ref) = object
+  method put char = cell := Some char
+  method flush () = ()
+  method close_out () = ()
+end
+
 let read_char term =
   begin
     Lwt_stream.get term.input_stream >>= fun byte_opt ->
@@ -323,12 +324,30 @@ let read_char term =
       | Some byte -> return byte
       | None -> Lwt.fail End_of_file
   end >>= fun first_byte ->
-  LTerm_unix.parse_char term.incoming_encoding term.input_stream first_byte >>= fun char ->
+  let cell = ref None in
+  let output = new CharEncoding.convert_uchar_output term.incoming_encoding (new output_single cell) in
+  let rec loop st =
+    match !cell with
+      | Some char ->
+          return char
+      | None ->
+          Lwt_stream.next st >>= fun byte ->
+          assert (output#output (Bytes.make 1 byte) 0 1 = 1);
+          output#flush ();
+          loop st
+  in
+  Lwt.catch (fun () ->
+      assert (output#output (Bytes.make 1 first_byte) 0 1 = 1);
+      Lwt_stream.parse term.input_stream loop)
+    (function
+    | CharEncoding.Malformed_code | Lwt_stream.Empty ->
+      return (UChar.of_char first_byte)
+    | exn -> Lwt.fail exn) >>= fun char ->
   return (LTerm_event.Key {
             LTerm_key.control = false;
             LTerm_key.meta = false;
             LTerm_key.shift = false;
-            LTerm_key.code = LTerm_key.Char char;
+            LTerm_key.code = LTerm_key.Char (Uchar.of_int (UChar.code char));
           })
 
 let rec next_event term =
@@ -697,23 +716,23 @@ let load_state term =
    | String recoding                                                 |
    +-----------------------------------------------------------------+ *)
 
-(*
-let vline = Uchar.of_char '|'
-let vlline = Uchar.of_char '+'
-let dlcorner = Uchar.of_char '+'
-let urcorner = Uchar.of_char '+'
-let huline = Uchar.of_char '+'
-let hdline = Uchar.of_char '+'
-let vrline = Uchar.of_char '+'
-let hline = Uchar.of_char '-'
-let cross = Uchar.of_char '+'
-let ulcorner = Uchar.of_char '+'
-let drcorner = Uchar.of_char '+'
-let question = Uchar.of_char '?'
-*)
+let vline = UChar.of_char '|'
+let vlline = UChar.of_char '+'
+let dlcorner = UChar.of_char '+'
+let urcorner = UChar.of_char '+'
+let huline = UChar.of_char '+'
+let hdline = UChar.of_char '+'
+let vrline = UChar.of_char '+'
+let hline = UChar.of_char '-'
+let cross = UChar.of_char '+'
+let ulcorner = UChar.of_char '+'
+let drcorner = UChar.of_char '+'
+let question = UChar.of_char '?'
+
+module UNF = UNF.Make (UText)
 
 (* Map characters that cannot be encoded to ASCII ones. *)
-(* let map_char char =
+let map_char char =
   match Uchar.to_int char with
     | 0x2500 -> hline
     | 0x2501 -> hline
@@ -798,6 +817,7 @@ let question = Uchar.of_char '?'
     | 0x2550 -> hline
     | 0x2551 -> vline
     | _ ->
+        let char = UChar.chr (Uchar.to_int char) in
         match UNF.nfd_decompose char with
           | char :: _ ->
               if UChar.code char <= 127 then
@@ -806,7 +826,15 @@ let question = Uchar.of_char '?'
                 question
           | [] ->
               question
-*)
+
+class output_to_buffer buf res = object
+  method output str ofs len =
+    Buffer.add_subbytes buf str ofs len;
+    len
+  method flush () = ()
+  method close_out () =
+    res := Buffer.contents buf
+end
 
 let encode_string term str =
   if term.outgoing_is_utf8 then
@@ -814,14 +842,18 @@ let encode_string term str =
     str
   else
     let buf = Buffer.create (String.length str) in
-    let e = Uutf.encoder term.outgoing_encoding (`Buffer buf) in
+    let res = ref "" in
+    let output = new CharEncoding.uchar_output_channel_of term.outgoing_encoding (new output_to_buffer buf res) in
     let rec loop ofs =
       if ofs = String.length str then begin
-        assert (Uutf.encode e `End = `Ok);
-        Buffer.contents buf
+        output#close_out ();
+        !res
       end else begin
         let ch, ofs = Zed_utf8.unsafe_extract_next str ofs in
-        assert (Uutf.encode e (`Uchar ch) = `Ok);
+        (try
+           output#put (UChar.chr (Uchar.to_int ch))
+         with CharEncoding.Out_of_range | UChar.Out_of_range ->
+           output#put (map_char ch));
         loop ofs
       end
     in
@@ -831,11 +863,14 @@ let encode_char term ch =
   if term.outgoing_is_utf8 then
     Zed_utf8.singleton ch
   else begin
-    let buf = Buffer.create 8 in
-    let e = Uutf.encoder term.outgoing_encoding (`Buffer buf) in
-    assert (Uutf.encode e (`Uchar ch) = `Ok);
-    assert (Uutf.encode e `End = `Ok);
-    Buffer.contents buf
+    let res = ref "" in
+    let output = new CharEncoding.uchar_output_channel_of term.outgoing_encoding (new output_to_buffer (Buffer.create 8) res) in
+    (try
+       output#put (UChar.chr (Uchar.to_int ch))
+     with CharEncoding.Out_of_range | UChar.Out_of_range ->
+       output#put (map_char ch));
+    output#close_out ();
+    !res
   end
 
 (* +-----------------------------------------------------------------+

--- a/src/lTerm.mli
+++ b/src/lTerm.mli
@@ -9,8 +9,6 @@
 
 (** Terminal definitions *)
 
-open CamomileLibrary
-
 type t
   (** Type of terminals. *)
 
@@ -22,8 +20,8 @@ exception No_such_encoding of string
 val create :
   ?windows : bool ->
   ?model : string ->
-  ?incoming_encoding : string ->
-  ?outgoing_encoding : string ->
+  ?incoming_encoding : Uutf.decoder_encoding ->
+  ?outgoing_encoding : Uutf.encoding ->
   Lwt_unix.file_descr -> Lwt_io.input_channel ->
   Lwt_unix.file_descr -> Lwt_io.output_channel -> t Lwt.t
   (** [create ?windows ?model ?incoming_encoding ?outgoing_encoding
@@ -49,9 +47,6 @@ val create :
       [true] and [LTerm_unix.system_encoding] otherwise. Note that
       transliteration is used so printing unicode character on the
       terminal will never fail.
-
-      If one of the two given encodings does not exist, it raises
-      [No_such_encoding].
 
       Note about terminal resize: in the windows console resizes are
       not automatically detected. Lambda-term will only check for
@@ -288,7 +283,7 @@ val encode_string : t -> Zed_utf8.t -> string
   (** [encode_string term str] encodes an UTF-8 string using the
       terminal encoding. *)
 
-val encode_char : t -> UChar.t -> string
+val encode_char : t -> Uchar.t -> string
   (** [encode_char term ch] encodes an unicode character using the
       terminal encoding. *)
 

--- a/src/lTerm.mli
+++ b/src/lTerm.mli
@@ -20,8 +20,8 @@ exception No_such_encoding of string
 val create :
   ?windows : bool ->
   ?model : string ->
-  ?incoming_encoding : Uutf.decoder_encoding ->
-  ?outgoing_encoding : Uutf.encoding ->
+  ?incoming_encoding : string ->
+  ?outgoing_encoding : string ->
   Lwt_unix.file_descr -> Lwt_io.input_channel ->
   Lwt_unix.file_descr -> Lwt_io.output_channel -> t Lwt.t
   (** [create ?windows ?model ?incoming_encoding ?outgoing_encoding
@@ -47,6 +47,9 @@ val create :
       [true] and [LTerm_unix.system_encoding] otherwise. Note that
       transliteration is used so printing unicode character on the
       terminal will never fail.
+
+      If one of the two given encodings does not exist, it raises
+      [No_such_encoding].
 
       Note about terminal resize: in the windows console resizes are
       not automatically detected. Lambda-term will only check for

--- a/src/lTerm_buttons_impl.ml
+++ b/src/lTerm_buttons_impl.ml
@@ -8,7 +8,6 @@
  *)
 
 module Make (LiteralIntf: LiteralIntf.Type) = struct
-  open CamomileLibraryDefault.Camomile
   open LTerm_geom
   open LTerm_key
   open LTerm_mouse
@@ -18,7 +17,7 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
 
   class t = LTerm_widget_base_impl.t
 
-  let space = Char(UChar.of_char ' ')
+  let space = Char(Uchar.of_char ' ')
 
   class button ?brackets initial_label =
     let (bl, br)=

--- a/src/lTerm_draw.ml
+++ b/src/lTerm_draw.ml
@@ -8,7 +8,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
 open LTerm_geom
 open Result
 
@@ -427,7 +426,7 @@ type connection =
 type piece = { top : connection; bottom : connection; left : connection; right : connection }
 
 let piece_of_char char =
-  match UChar.code char with
+  match Uchar.to_int char with
     | 0x2500 -> Some { top = Blank; bottom = Blank; left = Light; right = Light }
     | 0x2501 -> Some { top = Blank; bottom = Blank; left = Heavy; right = Heavy }
     | 0x2502 -> Some { top = Light; bottom = Light; left = Blank; right = Blank }
@@ -511,87 +510,87 @@ let piece_of_char char =
     | _ -> None
 
 let char_of_piece = function
-  | { top = Blank; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x0020
-  | { top = Blank; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2500
-  | { top = Blank; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x2501
-  | { top = Light; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x2502
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x2503
-  | { top = Blank; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x250c
-  | { top = Blank; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x250d
-  | { top = Blank; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x250e
-  | { top = Blank; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x250f
-  | { top = Blank; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2510
-  | { top = Blank; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2511
-  | { top = Blank; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2512
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x2513
-  | { top = Light; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2514
-  | { top = Light; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x2515
-  | { top = Heavy; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2516
-  | { top = Heavy; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x2517
-  | { top = Light; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x2518
-  | { top = Light; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x2519
-  | { top = Heavy; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x251a
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x251b
-  | { top = Light; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x251c
-  | { top = Light; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x251d
-  | { top = Heavy; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x251e
-  | { top = Light; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x251f
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x2520
-  | { top = Heavy; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x2521
-  | { top = Light; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x2522
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x2523
-  | { top = Light; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2524
-  | { top = Light; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2525
-  | { top = Heavy; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2526
-  | { top = Light; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2527
-  | { top = Heavy; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2528
-  | { top = Heavy; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2529
-  | { top = Light; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x252a
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x252b
-  | { top = Blank; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x252c
-  | { top = Blank; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x252d
-  | { top = Blank; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x252e
-  | { top = Blank; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x252f
-  | { top = Blank; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2530
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2531
-  | { top = Blank; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x2532
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x2533
-  | { top = Light; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2534
-  | { top = Light; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x2535
-  | { top = Light; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x2536
-  | { top = Light; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x2537
-  | { top = Heavy; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2538
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x2539
-  | { top = Heavy; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x253a
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x253b
-  | { top = Light; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x253c
-  | { top = Light; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x253d
-  | { top = Light; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x253e
-  | { top = Light; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x253f
-  | { top = Heavy; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x2540
-  | { top = Light; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2541
-  | { top = Heavy; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2542
-  | { top = Heavy; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x2543
-  | { top = Heavy; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x2544
-  | { top = Light; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2545
-  | { top = Light; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x2546
-  | { top = Heavy; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x2547
-  | { top = Light; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x2548
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2549
-  | { top = Heavy; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x254a
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x254b
-  | { top = Blank; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x2574
-  | { top = Light; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x2575
-  | { top = Blank; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2576
-  | { top = Blank; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x2577
-  | { top = Blank; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x2578
-  | { top = Heavy; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x2579
-  | { top = Blank; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x257a
-  | { top = Blank; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x257b
-  | { top = Blank; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x257c
-  | { top = Light; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x257d
-  | { top = Blank; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x257e
-  | { top = Heavy; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x257f
+  | { top = Blank; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x0020
+  | { top = Blank; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2500
+  | { top = Blank; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x2501
+  | { top = Light; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x2502
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x2503
+  | { top = Blank; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x250c
+  | { top = Blank; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x250d
+  | { top = Blank; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x250e
+  | { top = Blank; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x250f
+  | { top = Blank; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2510
+  | { top = Blank; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2511
+  | { top = Blank; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2512
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x2513
+  | { top = Light; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2514
+  | { top = Light; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x2515
+  | { top = Heavy; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2516
+  | { top = Heavy; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x2517
+  | { top = Light; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x2518
+  | { top = Light; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x2519
+  | { top = Heavy; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x251a
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x251b
+  | { top = Light; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x251c
+  | { top = Light; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x251d
+  | { top = Heavy; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x251e
+  | { top = Light; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x251f
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x2520
+  | { top = Heavy; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x2521
+  | { top = Light; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x2522
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x2523
+  | { top = Light; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2524
+  | { top = Light; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2525
+  | { top = Heavy; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2526
+  | { top = Light; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2527
+  | { top = Heavy; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2528
+  | { top = Heavy; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2529
+  | { top = Light; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x252a
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x252b
+  | { top = Blank; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x252c
+  | { top = Blank; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x252d
+  | { top = Blank; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x252e
+  | { top = Blank; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x252f
+  | { top = Blank; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2530
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2531
+  | { top = Blank; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x2532
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x2533
+  | { top = Light; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2534
+  | { top = Light; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x2535
+  | { top = Light; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x2536
+  | { top = Light; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x2537
+  | { top = Heavy; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2538
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x2539
+  | { top = Heavy; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x253a
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x253b
+  | { top = Light; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x253c
+  | { top = Light; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x253d
+  | { top = Light; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x253e
+  | { top = Light; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x253f
+  | { top = Heavy; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x2540
+  | { top = Light; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2541
+  | { top = Heavy; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2542
+  | { top = Heavy; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x2543
+  | { top = Heavy; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x2544
+  | { top = Light; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2545
+  | { top = Light; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x2546
+  | { top = Heavy; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x2547
+  | { top = Light; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x2548
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2549
+  | { top = Heavy; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x254a
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x254b
+  | { top = Blank; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x2574
+  | { top = Light; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x2575
+  | { top = Blank; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2576
+  | { top = Blank; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x2577
+  | { top = Blank; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x2578
+  | { top = Heavy; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x2579
+  | { top = Blank; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x257a
+  | { top = Blank; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x257b
+  | { top = Blank; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x257c
+  | { top = Light; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x257d
+  | { top = Blank; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x257e
+  | { top = Heavy; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x257f
 
 let piece_of_point point=
   match !point with

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -9,7 +9,6 @@
 
 let pervasives_compare= compare
 
-open CamomileLibraryDefault.Camomile
 open Zed_edit
 open LTerm_key
 open LTerm_geom
@@ -108,24 +107,24 @@ let () =
   bind [{ control = false; meta = false; shift = false; code = Insert }] [Zed Switch_erase_mode];
   bind [{ control = false; meta = false; shift = false; code = Delete }] [Zed Delete_next_char];
   bind [{ control = false; meta = false; shift = false; code = Enter }] [Zed Newline];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char ' ') }] [Zed Set_mark];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'a') }] [Zed Goto_bol];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'e') }] [Zed Goto_eol];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'd') }] [Zed Delete_next_char];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'h') }] [Zed Delete_prev_char];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') }] [Zed Kill_next_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'u') }] [Zed Kill_prev_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'n') }] [Zed Next_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'p') }] [Zed Prev_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'w') }] [Zed Kill];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'y') }] [Zed Yank];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char ' ') }] [Zed Set_mark];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'a') }] [Zed Goto_bol];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'e') }] [Zed Goto_eol];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'd') }] [Zed Delete_next_char];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'h') }] [Zed Delete_prev_char];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') }] [Zed Kill_next_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'u') }] [Zed Kill_prev_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'n') }] [Zed Next_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'p') }] [Zed Prev_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'w') }] [Zed Kill];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'y') }] [Zed Yank];
   bind [{ control = false; meta = false; shift = false; code = Backspace }] [Zed Delete_prev_char];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'w') }] [Zed Copy];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'c') }] [Zed Capitalize_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'l') }] [Zed Lowercase_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'u') }] [Zed Uppercase_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'b') }] [Zed Prev_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'f') }] [Zed Next_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'w') }] [Zed Copy];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'c') }] [Zed Capitalize_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'l') }] [Zed Lowercase_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'u') }] [Zed Uppercase_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'b') }] [Zed Prev_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'f') }] [Zed Next_word];
   bind [{ control = false; meta = true; shift = false; code = Right }] [Zed Next_word];
   bind [{ control = false; meta = true; shift = false; code = Left }] [Zed Prev_word];
   bind [{ control = true; meta = false; shift = false; code = Right }] [Zed Next_word];
@@ -133,21 +132,21 @@ let () =
   bind [{ control = false; meta = true; shift = false; code = Backspace }] [Zed Kill_prev_word];
   bind [{ control = false; meta = true; shift = false; code = Delete }] [Zed Kill_prev_word];
   bind [{ control = true; meta = false; shift = false; code = Delete }] [Zed Kill_next_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'd') }] [Zed Kill_next_word];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char '_') }] [Zed Undo];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char '(') }] [Start_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char ')') }] [Stop_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char 'e') }] [Play_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'g') }] [Cancel_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'd') }] [Zed Kill_next_word];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char '_') }] [Zed Undo];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char '(') }] [Start_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char ')') }] [Stop_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char 'e') }] [Play_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'g') }] [Cancel_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
         { control = false; meta = false; shift = false; code = Tab }] [Insert_macro_counter];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'a') }] [Add_macro_counter];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'c') }] [Set_macro_counter]
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'a') }] [Add_macro_counter];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'c') }] [Set_macro_counter]
 
 (* +-----------------------------------------------------------------+
    | Widgets                                                         |
@@ -156,20 +155,17 @@ let () =
 let clipboard = Zed_edit.new_clipboard ()
 let macro = Zed_macro.create []
 
-let regexp_word =
-  let set = UCharInfo.load_property_set `Alphabetic in
-  let set = List.fold_left (fun set ch -> USet.add (UChar.of_char ch) set) set ['0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9'] in
-  Zed_re.Core.compile (`Repn(`Set set, 1, None))
-
 let dummy_engine = Zed_edit.create ()
 let dummy_cursor = Zed_edit.new_cursor dummy_engine
 let dummy_context = Zed_edit.context dummy_engine dummy_cursor
-let newline = Zed_char.unsafe_of_uChar (UChar.of_char '\n')
+let newline = Zed_char.unsafe_of_uChar (Uchar.of_char '\n')
 
 class scrollable = object
   inherit LTerm_widget.scrollable
   method! calculate_range page_size document_size = (document_size - page_size/2)
 end
+
+let default_match_word _ _ = None
 
 class edit ?(clipboard = clipboard) ?(macro = macro) ?(size = { cols = 1; rows = 1 }) () =
   let locale, set_locale = S.create None in
@@ -205,7 +201,7 @@ object(self)
     current_line_style <- LTerm_resources.get_style (rc ^ ".current-line") resources
 
   method editable _pos _len = true
-  method match_word text pos = match_by_regexp_core regexp_word text pos
+  method match_word = default_match_word
   method locale = S.value locale
   method set_locale locale = set_locale locale
 
@@ -293,7 +289,7 @@ object(self)
     engine <- (
       Zed_edit.create
         ~editable:(fun pos len -> self#editable pos len)
-        ~match_word:(fun text pos -> self#match_word text pos)
+        ?match_word:(if self # match_word == default_match_word then None else Some self # match_word)
         ~clipboard
         ~locale
         ()

--- a/src/lTerm_history.ml
+++ b/src/lTerm_history.ml
@@ -7,8 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
-
 let return, (>>=) = Lwt.return, Lwt.(>>=)
 
 (* A node contains an entry of the history. *)
@@ -86,9 +84,7 @@ let create ?(max_size=max_int) ?(max_entries=max_int) init =
     cache = None;
   }
 
-let spaces = UCharInfo.load_property_tbl `White_Space
-
-let is_space_uChar ch = UCharTbl.Bool.get spaces ch
+let is_space_uChar ch = Uucp.White.is_white_space ch
 let is_space ch = Zed_char.for_all is_space_uChar ch
 let is_empty str = Zed_string.for_all is_space str
 

--- a/src/lTerm_inputrc.mll
+++ b/src/lTerm_inputrc.mll
@@ -8,7 +8,6 @@
  *)
 
 {
-  open CamomileLibraryDefault.Camomile
   open LTerm_key
 
   let return, (>>=) = Lwt.return, Lwt.(>>=)
@@ -285,7 +284,7 @@ and sequence key seq = parse
       }
   | [ 'a'-'z' 'A'-'Z' '0'-'9' '_' '(' ')' '[' ']' '{' '}' '~' '&' '$' '*' '%' '!' '?' ',' ';' '/' '\\' '.' '@' '=' '+' '-' '^' ] as ch (blank+ | ':' as sep)
       {
-        let seq = { key with code = Char(UChar.of_char ch) } :: seq in
+        let seq = { key with code = Char(Uchar.of_char ch) } :: seq in
         if sep = ":" then
           actions (List.rev seq) [] lexbuf
         else
@@ -303,7 +302,7 @@ and sequence key seq = parse
                | 'a' .. 'f' -> Char.code ch - Char.code 'a' + 10
                | _ -> assert false)
         done;
-        match try Some (UChar.of_int !code) with _ -> None with
+        match try Some (Uchar.of_int !code) with _ -> None with
           | Some ch ->
               let seq = { key with code = Char ch } :: seq in
               if sep = ":" then

--- a/src/lTerm_key.ml
+++ b/src/lTerm_key.ml
@@ -14,10 +14,8 @@ module String = struct
   include String
 end
 
-open CamomileLibraryDefault.Camomile
-
 type code =
-  | Char of UChar.t
+  | Char of Uchar.t
   | Enter
   | Escape
   | Tab
@@ -59,7 +57,7 @@ let meta key = key.meta
 let code key = key.code
 
 let string_of_code = function
-  | Char ch -> Printf.sprintf "Char 0x%02x" (UChar.code ch)
+  | Char ch -> Printf.sprintf "Char 0x%02x" (Uchar.to_int ch)
   | Enter -> "Enter"
   | Escape -> "Escape"
   | Tab -> "Tab"
@@ -97,7 +95,7 @@ let to_string_compact key =
   if key.shift then Buffer.add_string buffer "S-";
   (match key.code with
      | Char ch ->
-         let code = UChar.code ch in
+         let code = Uchar.to_int ch in
          if code <= 255 then
            match Char.chr code with
              | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9'

--- a/src/lTerm_key.mli
+++ b/src/lTerm_key.mli
@@ -9,11 +9,9 @@
 
 (** Keys *)
 
-open CamomileLibrary
-
 (** Type of key code. *)
 type code =
-  | Char of UChar.t
+  | Char of Uchar.t
       (** A unicode character. *)
   | Enter
   | Escape

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -9,7 +9,6 @@
 
 let pervasives_compare= compare
 
-open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_geom
 open LTerm_style
@@ -187,18 +186,18 @@ let () =
   bind [{ control = false; meta = false; shift = false; code = Down }] [History_next];
   bind [{ control = false; meta = false; shift = false; code = Tab }] [Complete];
   bind [{ control = false; meta = false; shift = false; code = Enter }] [Accept];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'b') }] [Edit (LTerm_edit.Zed Zed_edit.Prev_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'f') }] [Edit (LTerm_edit.Zed Zed_edit.Next_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'h') }] [Edit (LTerm_edit.Zed Zed_edit.Delete_prev_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'c') }] [Break];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'z') }] [Suspend];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'm') }] [Accept];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'l') }] [Clear_screen];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'r') }] [Prev_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 's') }] [Next_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'd') }] [Interrupt_or_delete_next_char];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'p') }] [History_prev];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'n') }] [History_next];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'b') }] [Edit (LTerm_edit.Zed Zed_edit.Prev_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'f') }] [Edit (LTerm_edit.Zed Zed_edit.Next_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'h') }] [Edit (LTerm_edit.Zed Zed_edit.Delete_prev_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'c') }] [Break];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'z') }] [Suspend];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'm') }] [Accept];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'l') }] [Clear_screen];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'r') }] [Prev_search];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 's') }] [Next_search];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'd') }] [Interrupt_or_delete_next_char];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'p') }] [History_prev];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'n') }] [History_next];
   bind [{ control = false; meta = true; shift = false; code = Left }] [Complete_bar_prev];
   bind [{ control = false; meta = true; shift = false; code = Right }] [Complete_bar_next];
   bind [{ control = false; meta = true; shift = false; code = Home }] [Complete_bar_first];
@@ -207,8 +206,8 @@ let () =
   bind [{ control = false; meta = true; shift = false; code = Down }] [Complete_bar];
   bind [{ control = false; meta = true; shift = false; code = Enter }] [Edit (LTerm_edit.Zed Zed_edit.Newline)];
   bind [{ control = false; meta = false; shift = false; code = Escape }] [Cancel_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }
-       ;{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'e') }]
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }
+       ;{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'e') }]
     [Edit_with_external_editor]
 
 (* +-----------------------------------------------------------------+
@@ -676,7 +675,7 @@ end
 class virtual ['a] abstract = object
   method virtual eval : 'a
   method virtual send_action : action -> unit
-  method virtual insert : UChar.t -> unit
+  method virtual insert : Uchar.t -> unit
   method virtual edit : unit Zed_edit.t
   method virtual context : unit Zed_edit.context
   method virtual clipboard : Zed_edit.clipboard
@@ -747,7 +746,7 @@ end
    | Running in a terminal                                           |
    +-----------------------------------------------------------------+ *)
 
-let newline_uChar = UChar.of_char '\n'
+let newline_uChar = Uchar.of_char '\n'
 let newline = Zed_char.unsafe_of_uChar @@ newline_uChar
 let vline = LTerm_draw.({ top = Light; bottom = Light; left = Blank; right = Blank })
 let reverse_style = { LTerm_style.none with LTerm_style.reverse = Some true }
@@ -1194,7 +1193,7 @@ object(self)
                     | { control = false; meta = false; shift = false; code = Char ch } ->
                         Zed_macro.add self#macro (Edit (LTerm_edit.Zed (Zed_edit.Insert (Zed_char.unsafe_of_uChar ch))));
                         self#insert ch
-                    | { code = Char ch; _ } when LTerm.windows term && UChar.code ch >= 32 ->
+                    | { code = Char ch; _ } when LTerm.windows term && Uchar.to_int ch >= 32 ->
                         (* Windows reports Shift+A for A, ... *)
                         Zed_macro.add self#macro (Edit (LTerm_edit.Zed (Zed_edit.Insert (Zed_char.unsafe_of_uChar ch))));
                         self#insert ch

--- a/src/lTerm_read_line.mli
+++ b/src/lTerm_read_line.mli
@@ -12,7 +12,6 @@
 (** For a complete example of usage of this module, look at the shell
     example (examples/shell.ml) distributed with Lambda-Term. *)
 
-open CamomileLibrary
 open React
 
 exception Interrupt
@@ -144,7 +143,7 @@ class virtual ['a] engine : ?history : history -> ?clipboard : Zed_edit.clipboar
 
   (** {6 Actions} *)
 
-  method insert : UChar.t -> unit
+  method insert : Uchar.t -> unit
     (** Inserts the given character. Note that is it also possible to
         manipulate directly the edition context. *)
 
@@ -221,7 +220,7 @@ end
 class virtual ['a] abstract : object
   method virtual eval : 'a
   method virtual send_action : action -> unit
-  method virtual insert : UChar.t -> unit
+  method virtual insert : Uchar.t -> unit
   method virtual edit : unit Zed_edit.t
   method virtual context : unit Zed_edit.context
   method virtual clipboard : Zed_edit.clipboard

--- a/src/lTerm_scroll_impl.ml
+++ b/src/lTerm_scroll_impl.ml
@@ -257,7 +257,7 @@ class virtual scrollbar
     let { cols; rows } = size_of_rect rect in
     if cols=1 || rows=1 || bar_style=`filled then
       let x =
-        CamomileLibrary.UChar.of_int @@
+        Uchar.of_int @@
           if bar_style=`filled then 0x2588
           else if cols=1 then vbar
           else hbar

--- a/src/lTerm_text_impl.ml
+++ b/src/lTerm_text_impl.ml
@@ -8,7 +8,6 @@
  *)
 
 module Make (LiteralIntf: LiteralIntf.Type) = struct
-  open CamomileLibraryDefault.Camomile
   open LTerm_style
   open Result
 
@@ -40,9 +39,9 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
 
   let uchar_of_hex x =
     if x < 10 then
-      UChar.of_int (Char.code '0' + x)
+      Uchar.of_int (Char.code '0' + x)
     else
-      UChar.of_int (Char.code 'a' + x - 10)
+      Uchar.of_int (Char.code 'a' + x - 10)
 
   let of_string_maybe_invalid str=
     let len= Zed_string.length str in
@@ -58,7 +57,7 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
             (ofs, idx + 1)
           with
             Zed_utf8.Invalid _->
-            let code= UChar.int_of (Zed_char.core (Zed_string.extract str ofs)) in
+            let code= Uchar.to_int (Zed_char.core (Zed_string.extract str ofs)) in
             Array.unsafe_set arr (idx + 0)
               (Zed_char.unsafe_of_char '\\', LTerm_style.none);
             Array.unsafe_set arr (idx + 1)

--- a/src/lTerm_unix.ml
+++ b/src/lTerm_unix.ml
@@ -7,7 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
 open LTerm_key
 
 let return, (>>=), (>|=) = Lwt.return, Lwt.(>>=), Lwt.(>|=)
@@ -324,32 +323,25 @@ let system_encoding =
    | Parsing of encoded characters                                   |
    +-----------------------------------------------------------------+ *)
 
-class output_single (cell : UChar.t option ref) = object
-  method put char = cell := Some char
-  method flush () = ()
-  method close_out () = ()
-end
-
 let parse_char encoding st first_byte =
-  let cell = ref None in
-  let output = new CharEncoding.convert_uchar_output encoding (new output_single cell) in
+  let d = Uutf.decoder ~encoding `Manual in
   let rec loop st =
-    match !cell with
-      | Some char ->
-          return char
-      | None ->
-          Lwt_stream.next st >>= fun byte ->
-          assert (output#output (Bytes.make 1 byte) 0 1 = 1);
-          output#flush ();
-          loop st
+    match Uutf.decode d with
+    | `Uchar u -> return u
+    | `End -> assert false
+    | `Malformed _ -> raise Exit
+    | `Await ->
+        Lwt_stream.next st >>= fun byte ->
+        Uutf.Manual.src d (Bytes.make 1 byte) 0 1;
+        loop st
   in
   Lwt.catch
     (fun () ->
-      assert (output#output (Bytes.make 1 first_byte) 0 1 = 1);
+      Uutf.Manual.src d (Bytes.make 1 first_byte) 0 1;
       Lwt_stream.parse st loop)
     (function
-    | CharEncoding.Malformed_code | Lwt_stream.Empty ->
-        return (UChar.of_char first_byte)
+    | Exit | Lwt_stream.Empty ->
+        return (Uchar.of_char first_byte)
     | exn -> Lwt.fail exn)
 
 (* +-----------------------------------------------------------------+
@@ -397,38 +389,38 @@ let parse_escape escape_time st =
    +-----------------------------------------------------------------+ *)
 
 let controls = [|
-  Char(UChar.of_char ' ');
-  Char(UChar.of_char 'a');
-  Char(UChar.of_char 'b');
-  Char(UChar.of_char 'c');
-  Char(UChar.of_char 'd');
-  Char(UChar.of_char 'e');
-  Char(UChar.of_char 'f');
-  Char(UChar.of_char 'g');
-  Char(UChar.of_char 'h');
+  Char(Uchar.of_char ' ');
+  Char(Uchar.of_char 'a');
+  Char(Uchar.of_char 'b');
+  Char(Uchar.of_char 'c');
+  Char(Uchar.of_char 'd');
+  Char(Uchar.of_char 'e');
+  Char(Uchar.of_char 'f');
+  Char(Uchar.of_char 'g');
+  Char(Uchar.of_char 'h');
   Tab;
   Enter;
-  Char(UChar.of_char 'k');
-  Char(UChar.of_char 'l');
-  Char(UChar.of_char 'm');
-  Char(UChar.of_char 'n');
-  Char(UChar.of_char 'o');
-  Char(UChar.of_char 'p');
-  Char(UChar.of_char 'q');
-  Char(UChar.of_char 'r');
-  Char(UChar.of_char 's');
-  Char(UChar.of_char 't');
-  Char(UChar.of_char 'u');
-  Char(UChar.of_char 'v');
-  Char(UChar.of_char 'w');
-  Char(UChar.of_char 'x');
-  Char(UChar.of_char 'y');
-  Char(UChar.of_char 'z');
+  Char(Uchar.of_char 'k');
+  Char(Uchar.of_char 'l');
+  Char(Uchar.of_char 'm');
+  Char(Uchar.of_char 'n');
+  Char(Uchar.of_char 'o');
+  Char(Uchar.of_char 'p');
+  Char(Uchar.of_char 'q');
+  Char(Uchar.of_char 'r');
+  Char(Uchar.of_char 's');
+  Char(Uchar.of_char 't');
+  Char(Uchar.of_char 'u');
+  Char(Uchar.of_char 'v');
+  Char(Uchar.of_char 'w');
+  Char(Uchar.of_char 'x');
+  Char(Uchar.of_char 'y');
+  Char(Uchar.of_char 'z');
   Escape;
-  Char(UChar.of_char '\\');
-  Char(UChar.of_char ']');
-  Char(UChar.of_char '^');
-  Char(UChar.of_char '_');
+  Char(Uchar.of_char '\\');
+  Char(Uchar.of_char ']');
+  Char(Uchar.of_char '^');
+  Char(Uchar.of_char '_');
 |]
 
 let sequences = [|
@@ -942,7 +934,7 @@ let rec parse_event ?(escape_time = 0.1) encoding stream =
                           (* Other ascii characters *)
                           Lwt_stream.junk stream >>= fun () ->
                           return(LTerm_event.Key  { control = false; meta = true;
-                                                    shift = false; code = Char(UChar.of_char byte) })
+                                                    shift = false; code = Char(Uchar.of_char byte) })
                       | byte' ->
                           Lwt_stream.junk stream >>= fun () ->
                           parse_char encoding stream byte' >>= fun code ->
@@ -963,7 +955,7 @@ let rec parse_event ?(escape_time = 0.1) encoding stream =
     | '\x00' .. '\x7f' ->
         (* Other ascii characters *)
         return (LTerm_event.Key { control = false; meta = false;
-                                  shift = false; code = Char(UChar.of_char byte) })
+                                  shift = false; code = Char(Uchar.of_char byte) })
     | _ ->
         (* Encoded characters *)
         parse_char encoding stream byte >>= fun code ->

--- a/src/lTerm_unix.mli
+++ b/src/lTerm_unix.mli
@@ -9,8 +9,6 @@
 
 (** Unix specific functions *)
 
-open CamomileLibraryDefault.Camomile
-
 val sigwinch : int option
   (** The number of the signal used to indicate that the terminal size
       have changed. It is [None] on windows. *)
@@ -18,7 +16,7 @@ val sigwinch : int option
 val system_encoding : string
   (** The encoding used by the system. *)
 
-val parse_event : ?escape_time : float -> CharEncoding.t -> char Lwt_stream.t -> LTerm_event.t Lwt.t
+val parse_event : ?escape_time : float -> Uutf.decoder_encoding -> char Lwt_stream.t -> LTerm_event.t Lwt.t
   (** [parse_event encoding stream] parses one event from the given
       input stream. [encoding] is the character encoding used to
       decode non-ascii characters. It must be a converter from the
@@ -26,3 +24,7 @@ val parse_event : ?escape_time : float -> CharEncoding.t -> char Lwt_stream.t ->
       encountered in the input, it fallbacks to Latin-1. [escape_time]
       is the time waited before returning the escape key. It defaults
       to [0.1]. *)
+
+(**/**)
+
+val parse_char : Uutf.decoder_encoding -> char Lwt_stream.t -> char -> Uchar.t Lwt.t

--- a/src/lTerm_unix.mli
+++ b/src/lTerm_unix.mli
@@ -9,6 +9,8 @@
 
 (** Unix specific functions *)
 
+open CamomileLibraryDefault.Camomile
+
 val sigwinch : int option
   (** The number of the signal used to indicate that the terminal size
       have changed. It is [None] on windows. *)
@@ -16,7 +18,7 @@ val sigwinch : int option
 val system_encoding : string
   (** The encoding used by the system. *)
 
-val parse_event : ?escape_time : float -> Uutf.decoder_encoding -> char Lwt_stream.t -> LTerm_event.t Lwt.t
+val parse_event : ?escape_time : float -> CharEncoding.t -> char Lwt_stream.t -> LTerm_event.t Lwt.t
   (** [parse_event encoding stream] parses one event from the given
       input stream. [encoding] is the character encoding used to
       decode non-ascii characters. It must be a converter from the
@@ -24,7 +26,3 @@ val parse_event : ?escape_time : float -> Uutf.decoder_encoding -> char Lwt_stre
       encountered in the input, it fallbacks to Latin-1. [escape_time]
       is the time waited before returning the escape key. It defaults
       to [0.1]. *)
-
-(**/**)
-
-val parse_char : Uutf.decoder_encoding -> char Lwt_stream.t -> char -> Uchar.t Lwt.t

--- a/src/lTerm_windows.ml
+++ b/src/lTerm_windows.ml
@@ -7,8 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
-
 let (>|=) = Lwt.(>|=)
 
 external get_acp : unit -> int = "lt_windows_get_acp"
@@ -25,38 +23,38 @@ type input =
 external read_console_input_job : Unix.file_descr -> input Lwt_unix.job = "lt_windows_read_console_input_job"
 
 let controls = [|
-  UChar.of_char ' ';
-  UChar.of_char 'a';
-  UChar.of_char 'b';
-  UChar.of_char 'c';
-  UChar.of_char 'd';
-  UChar.of_char 'e';
-  UChar.of_char 'f';
-  UChar.of_char 'g';
-  UChar.of_char 'h';
-  UChar.of_char 'i';
-  UChar.of_char 'j';
-  UChar.of_char 'k';
-  UChar.of_char 'l';
-  UChar.of_char 'm';
-  UChar.of_char 'n';
-  UChar.of_char 'o';
-  UChar.of_char 'p';
-  UChar.of_char 'q';
-  UChar.of_char 'r';
-  UChar.of_char 's';
-  UChar.of_char 't';
-  UChar.of_char 'u';
-  UChar.of_char 'v';
-  UChar.of_char 'w';
-  UChar.of_char 'x';
-  UChar.of_char 'y';
-  UChar.of_char 'z';
-  UChar.of_char '[';
-  UChar.of_char '\\';
-  UChar.of_char ']';
-  UChar.of_char '^';
-  UChar.of_char '_';
+  Uchar.of_char ' ';
+  Uchar.of_char 'a';
+  Uchar.of_char 'b';
+  Uchar.of_char 'c';
+  Uchar.of_char 'd';
+  Uchar.of_char 'e';
+  Uchar.of_char 'f';
+  Uchar.of_char 'g';
+  Uchar.of_char 'h';
+  Uchar.of_char 'i';
+  Uchar.of_char 'j';
+  Uchar.of_char 'k';
+  Uchar.of_char 'l';
+  Uchar.of_char 'm';
+  Uchar.of_char 'n';
+  Uchar.of_char 'o';
+  Uchar.of_char 'p';
+  Uchar.of_char 'q';
+  Uchar.of_char 'r';
+  Uchar.of_char 's';
+  Uchar.of_char 't';
+  Uchar.of_char 'u';
+  Uchar.of_char 'v';
+  Uchar.of_char 'w';
+  Uchar.of_char 'x';
+  Uchar.of_char 'y';
+  Uchar.of_char 'z';
+  Uchar.of_char '[';
+  Uchar.of_char '\\';
+  Uchar.of_char ']';
+  Uchar.of_char '^';
+  Uchar.of_char '_';
 |]
 
 let read_console_input fd =
@@ -64,8 +62,8 @@ let read_console_input fd =
   Lwt_unix.run_job ?async_method:None
    (read_console_input_job (Lwt_unix.unix_file_descr fd))
   >|= function
-  | Key({ LTerm_key.code = LTerm_key.Char ch ; _ } as key) when UChar.code ch < 32 ->
-    Key { key with LTerm_key.code = LTerm_key.Char controls.(UChar.code ch) }
+  | Key({ LTerm_key.code = LTerm_key.Char ch ; _ } as key) when Uchar.to_int ch < 32 ->
+    Key { key with LTerm_key.code = LTerm_key.Char controls.(Uchar.to_int ch) }
   | input ->
     input
 
@@ -149,7 +147,7 @@ let write_console_output fd chars size coord rect =
     chars;
   write_console_output (Lwt_unix.unix_file_descr fd) chars size coord rect
 
-external fill_console_output_character : Unix.file_descr -> UChar.t -> int -> LTerm_geom.coord -> int = "lt_windows_fill_console_output_character"
+external fill_console_output_character : Unix.file_descr -> Uchar.t -> int -> LTerm_geom.coord -> int = "lt_windows_fill_console_output_character"
 
 let fill_console_output_character fd char count coord =
   Lwt_unix.check_descriptor fd;

--- a/src/lTerm_windows.mli
+++ b/src/lTerm_windows.mli
@@ -11,8 +11,6 @@
 
 (** All these functions return [Lwt_sys.Not_available] on Unix. *)
 
-open CamomileLibrary
-
 (** {6 Codepage functions} *)
 
 val get_acp : unit -> int
@@ -129,7 +127,7 @@ val write_console_output : Lwt_unix.file_descr -> char_info array array -> LTerm
       matrix of characters with their attributes on the given console
       at given position. *)
 
-val fill_console_output_character : Lwt_unix.file_descr -> UChar.t -> int -> LTerm_geom.coord -> int
+val fill_console_output_character : Lwt_unix.file_descr -> Uchar.t -> int -> LTerm_geom.coord -> int
   (** [fill_console_output_character fd char count coord] writes
       [count] times [char] starting at [coord] on the given
       console. *)

--- a/src/literalIntf.ml
+++ b/src/literalIntf.ml
@@ -1,5 +1,3 @@
-open CamomileLibrary
-
 module type Type =
   sig
     type char_intf
@@ -7,8 +5,8 @@ module type Type =
     val empty_string : unit -> string_intf
     val of_char : Zed_char.t -> char_intf
     val of_string : Zed_string.t -> string_intf
-    val to_char : char_intf -> Zed_char.t option * UChar.t list
-    val to_string : string_intf -> Zed_string.t * UChar.t list
+    val to_char : char_intf -> Zed_char.t option * Uchar.t list
+    val to_string : string_intf -> Zed_string.t * Uchar.t list
     val to_char_exn : char_intf -> Zed_char.t
     val to_string_exn : string_intf -> Zed_string.t
   end
@@ -17,7 +15,7 @@ module Zed : Type
   with type char_intf= Zed_char.t
   and type string_intf= Zed_string.t =
 struct
-  external id : 'a -> 'a = "%identity"
+  let id x = x
   type char_intf= Zed_char.t
   type string_intf= Zed_string.t
 
@@ -34,18 +32,15 @@ module UTF8 : Type
   with type char_intf= Zed_utf8.t
   and type string_intf= Zed_utf8.t =
 struct
-  module Zed_char_UTF8 = Zed_char.US(UTF8)
-  module Zed_string_UTF8 = Zed_string.US(UTF8)
-
   type char_intf= Zed_utf8.t
   type string_intf= Zed_utf8.t
 
   let empty_string ()= ""
   let of_char= Zed_char.to_utf8
   let of_string= Zed_string.to_utf8
-  let to_char= Zed_char_UTF8.to_t
-  let to_string= Zed_string_UTF8.to_t
-  let to_char_exn= Zed_char_UTF8.to_t_exn
-  let to_string_exn= Zed_string.unsafe_of_utf8
+  let to_char x = Zed_char.of_uChars (Zed_utf8.explode x)
+  let to_string x = Zed_string.of_uChars (Zed_utf8.explode x)
+  let to_char_exn x = match to_char x with Some t, _ -> t | _ -> failwith "to_t_exn"
+  let to_string_exn = Zed_string.unsafe_of_utf8
 end
 


### PR DESCRIPTION
This is a companion PR to https://github.com/ocaml-community/zed/pull/16, swapping out `camomile` for `uu*`. The main issue that needs working out is that `uutf` only supports conversion into
```
type encoding = [ `UTF_16 | `UTF_16BE | `UTF_16LE | `UTF_8 ]
```
This means that the "outgoing encoding" of `lambda-term` must be one of these. This is probably not a big deal on Linux where UTF-8 usage is pervasive, but on the Windows console Latin-1 is widespread and this would not be supported anymore.

/cc @Drup @diml 