### PR TITLE
android: workaround for nl_langinfo with API < 26

### DIFF
--- a/src/lTerm_unix_stubs.c
+++ b/src/lTerm_unix_stubs.c
@@ -56,6 +56,8 @@ CAMLprim value lt_unix_get_system_encoding()
   /* Get the codeset used by current locale: */
 #if defined(SYS_openbsd)
   const char *codeset = locale_charset();
+#elif defined(__ANDROID__) && __ANDROID_API__ < 26
+  const char *codeset = NULL;
 #else
   const char *codeset = nl_langinfo(CODESET);
 #endif


### PR DESCRIPTION
Android before API 26 didn't have `nl_langinfo` as you can see [here](https://github.com/EdgeApp/android-ndk-linux/blob/master/sysroot/usr/include/langinfo.h#L97).

I tried to find another way to get this information but it doesn't seems to be possible. So this PR implements a fallback to ASCII and allows it to build with NDK.