### PR TITLE
Respect XDG for the inputrc config file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Next
+----
+
+* Load inputrc file from ~/.config/.lambda-term-inputrc as per XDG conventions (@copy)
+
 2.0.3 (2019-12-31)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can then send the result to jeremie@dimino.org, including:
 Key bindings
 ------------
 
-Key bindings can be set in `~/.lambda-term-inputrc`. See
+Key bindings can be set in `~/.config/.lambda-term-inputrc`. See
 [lambda-term-inputrc](lambda-term-inputrc). Useful mappings:
 
 ```

--- a/lambda-term-inputrc
+++ b/lambda-term-inputrc
@@ -1,6 +1,6 @@
 # -*- conf-colon -*-
 
-# Copy this file to your ~/.lambda-term-inputrc
+# Copy this file to your ~/.config/.lambda-term-inputrc
 
 [read-line]
 

--- a/man/lambda-term-actions.1
+++ b/man/lambda-term-actions.1
@@ -17,7 +17,7 @@ lambda-term-actions \- Display lambda-term editing actions
 
 .B lambda-term-actions
 displays the list of actions that can be used in the
-~/.lambda-term-inputrc file.
+~/.config/.lambda-term-inputrc file.
 
 .SH AUTHOR
 Jérémie Dimino <jeremie@dimino.org>

--- a/man/lambda-term-inputrc.5
+++ b/man/lambda-term-inputrc.5
@@ -11,12 +11,12 @@
 lambda-term-inputrc \- Key bindings for lambda-term applications
 
 .SH SYNOPSIS
-.B ~/.lambda-term-inputrc
+.B ~/.config/.lambda-term-inputrc
 
 .SH DESCRIPTION
 
 This manual page describes the format of the
-.I ~/.lambda-term-inputrc
+.I ~/.config/.lambda-term-inputrc
 file. This file is a text file which associates editing actions to key
 sequences. Comments start with a '#' character and empty lines are
 ignored.
@@ -87,7 +87,7 @@ where
 is the code of the character in hexadecimal.
 
 .SH FILES
-.I ~/.lambda-term-inputrc
+.I ~/.config/.lambda-term-inputrc
 
 .SH EXAMPLE
 [edit]

--- a/src/lTerm_inputrc.mli
+++ b/src/lTerm_inputrc.mli
@@ -15,8 +15,9 @@ exception Parse_error of string * int * string
 
 val load : ?file : string -> unit -> unit Lwt.t
   (** [load ?file ()] loads key bindings from [file], which defaults
-      to ~/.lambda-term-inputrc, if it exists. *)
+      to ~/.config/.lambda-term-inputrc, if it exists. *)
 
 val default : string
   (** The name of the default key bindings file,
-      i.e. ~/.lambda-term-inputrc. *)
+      i.e. ~/.config/.lambda-term-inputrc
+      or the legacy location ~/.lambda-term-inputrc, if it exists *)

--- a/src/lTerm_inputrc.mll
+++ b/src/lTerm_inputrc.mll
@@ -334,7 +334,10 @@ and comma_actions seq l = parse
 
 {
   let default =
-    Filename.concat LTerm_resources.home ".lambda-term-inputrc"
+    LTerm_resources.xdgbd_file
+      ~loc:LTerm_resources.Config
+      ~allow_legacy_location:true
+      ".lambda-term-inputrc"
 
   let load ?(file = default) () =
     Lwt.catch (fun () ->


### PR DESCRIPTION
Moves the .lambda-term-inputrc config file to ~/.config/.lambda-term-inputrc.

Prints a warning if `~/.lambda-term-inputrc` exists, but still uses it.