### PR TITLE
3.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-3.0.0 (2020-04-24)
+3.0.0 (2020-04-25)
 ------------------
 
 ### Additions
@@ -9,11 +9,30 @@
   * `method editor_mode : LTerm_editor.mode signal`: the current editor mode
   * `method set_editor_mode : LTerm_editor.mode -> unit`: set the current editor mode
 
+Add initial support for vi editing mode to `LTerm_read_line`:
+  * motions:
+    * h l 0 ^ $
+    * j k gg G
+    * w W e E b B ge gE
+    * f F t T
+    * aw iw aW iW
+    * include or inner ( ), [ ], { }, < >, ' and "
+    * generic quote: aq? iq? where ? could be any character
+    * bracket matching: jump back and forth between matched brakcets
+  * delete, change, yank with motions
+  * paste: p P
+  * line joining: J
+
 ### Breaking
 
-`LTerm_read_line: class virtual ['a] term`: the type signature of `method private exec` is changed to `?keys : LTerm_key.t list -> action list -> 'a loop_result Lwt.t` from `method private exec : action list -> 'a Lwt.t`
+  * `LTerm_read_line
+    * class virtual ['a] term`: the type signature of `method private exec` is changed
+      from
+      `method private exec : action list -> 'a Lwt.t`
+      to
+      `?keys : LTerm_key.t list -> action list -> 'a loop_result Lwt.t`
 
-Since this is a private method and is intended to be used internally, the backward-compatibility is not affeted in most cases.
+Since this is a private method and is intended to be used internally, the backward-compatibility will not be affected in most cases.
 
 ### General
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Add initial support for vi editing mode to `LTerm_read_line`:
   * paste: p P
   * line joining: J
 
+Many thanks to @nilsbecker for his feature-request on vi edit mode and the helps during the development on this topic!
+
 ### Breaking
 
   * `LTerm_read_line

--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -14,10 +14,11 @@ depends: [
   "lwt"   {>= "4.0.0"}
   "lwt_log"
   "react"
-  "zed"   {>= "2.0.3" & < "3.0"}
+  "zed"   {>= "3.0.0" & < "4.0"}
   "camomile" {>= "1.0.1"}
   "lwt_react"
-  "dune" {>= "1.0.0"}
+  "mew_vi"  {>= "0.3.0" & < "1.0.0"}
+  "dune" {>= "1.1.0"}
 ]
 synopsis: "Terminal manipulation library for OCaml"
 description: """


### PR DESCRIPTION
3.0.0 (2020-04-25)
------------------

### Additions

* `LTerm_editor`: two editor modes: default and vi

* `LTerm_read_line: class virtual ['a] term`:
  * `method editor_mode : LTerm_editor.mode signal`: the current editor mode
  * `method set_editor_mode : LTerm_editor.mode -> unit`: set the current editor mode

Add initial support for vi editing mode to `LTerm_read_line`:
  * motions:
    * h l 0 ^ $
    * j k gg G
    * w W e E b B ge gE
    * f F t T
    * aw iw aW iW
    * include or inner ( ), [ ], { }, < >, ' and "
    * generic quote: aq? iq? where ? could be any character
    * bracket matching: jump back and forth between matched brakcets
  * delete, change, yank with motions
  * paste: p P
  * line joining: J

Many thanks to @nilsbecker for his feature-request on vi edit mode and the helps during the development on this topic!

### Breaking

  * `LTerm_read_line
    * class virtual ['a] term`: the type signature of `method private exec` is changed
      from
      `method private exec : action list -> 'a Lwt.t`
      to
      `?keys : LTerm_key.t list -> action list -> 'a loop_result Lwt.t`

Since this is a private method and is intended to be used internally, the backward-compatibility will not be affected in most cases.

### General

* Load inputrc file from ~/.config/.lambda-term-inputrc as per XDG conventions (@copy)

