### PR TITLE
LTerm_read_line: fix slow pasting

### DIFF
--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -1162,8 +1162,14 @@ object(self)
 
   (* The main loop. *)
   method private loop =
+    let read_event=
+      match vi_edit with
+      | Some _->
+        Lwt.pause () >>= fun ()-> Lwt.(>|=) (LTerm.read_event term) (fun ev-> Ev ev)
+      | None-> Lwt.(>|=) (LTerm.read_event term) (fun ev-> Ev ev)
+    in
     Lwt.pick [
-      (Lwt.pause () >>= fun ()-> Lwt.(>|=) (LTerm.read_event term) (fun ev-> Ev ev));
+      read_event;
       Lwt.(>|=) (Lwt_mvar.take result) (fun r-> Loop_result r);
       Lwt.(>|=) (Lwt_mvar.take self#interrupt) (fun e-> Interrupted e);
       ]


### PR DESCRIPTION
This PR fixes https://github.com/ocaml-community/utop/issues/324 within the default editing mode.
But within the vi editing mode, this _issue_ is remained, since the vi interpreter thread is separate between the main thread, we need such a synchronization lag to synchronize them.