### PR TITLE
3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-next
+3.1.0 (2020-05-30)
 ------------------
 
 * `LTerm_read_line` and `LTerm_vi`:

--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -17,7 +17,7 @@ depends: [
   "zed"   {>= "3.0.0" & < "4.0"}
   "camomile" {>= "1.0.1"}
   "lwt_react"
-  "mew_vi"  {>= "0.4.0" & < "0.5.0"}
+  "mew_vi"  {>= "0.5.0" & < "0.6.0"}
   "dune" {>= "1.1.0"}
 ]
 synopsis: "Terminal manipulation library for OCaml"

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -817,6 +817,8 @@ object(self)
 
   val mutable vi_thread= None
 
+  method vi_state= vi_state
+
   method set_editor_mode mode =
     set_editor_mode mode;
     match mode with

--- a/src/lTerm_read_line.mli
+++ b/src/lTerm_read_line.mli
@@ -315,6 +315,9 @@ class virtual ['a] term : LTerm.t -> object
   method set_editor_mode : LTerm_editor.mode -> unit
     (** Set the current editor mode. *)
 
+  method vi_state : LTerm_vi.state
+    (** Get the current vi_state . *)
+
   method bind : LTerm_key.t list -> action list -> unit
 
   method draw_update : unit Lwt.t


### PR DESCRIPTION
3.1.0 (2020-05-30)
------------------

* `LTerm_read_line` and `LTerm_vi`:
  * vi visual mode
  * register support