### PR TITLE
readme: link to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ a C library.
 Lambda-Term integrates with zed to provide text edition facilities in
 console applications.
 
+[API Documentation](https://ocaml-community.github.io/lambda-term/)
+
 Installation
 ------------
 


### PR DESCRIPTION
I created a github pages branch for lambda-term (sorry, can't PR an orphan branch so I had to just create it) modeled after that of [Containers](https://c-cube.github.io/ocaml-containers/). This is the added link in the README.