### PR TITLE
Enable mouse support in clock example

### DIFF
--- a/examples/clock.ml
+++ b/examples/clock.ml
@@ -33,8 +33,10 @@ let main () =
   button#on_click (wakeup wakener);
 
   (* Run in the standard terminal. *)
-  Lazy.force LTerm.stdout
-  >>= fun term ->
-  run term vbox waiter
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+  Lwt.finalize
+    (fun () -> run term vbox waiter)
+    (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())


### PR DESCRIPTION
Adds mouse support in clock example for #98 