### PR TITLE
Fix mouse handling in modal scenario.

### DIFF
--- a/examples/modal.ml
+++ b/examples/modal.ml
@@ -1,3 +1,4 @@
+open Lwt
 open LTerm_widget
 
 let main () =
@@ -53,6 +54,10 @@ let main () =
   (* set 'change' button to open modal layer *)
   change#on_click (push_layer layer2);
 
-  do_run frame
+  Lazy.force LTerm.stdout >>= fun term ->
+  LTerm.enable_mouse term >>= fun () ->
+    Lwt.finalize
+      (fun () -> do_run frame)
+      (fun () -> LTerm.disable_mouse term)
 
 let () = Lwt_main.run (main ())

--- a/src/lTerm_running_impl.ml
+++ b/src/lTerm_running_impl.ml
@@ -158,10 +158,11 @@ let run_modal term ?save_state ?(load_resources = true) ?(resources_file = lambd
           loop ()
       (* left button mouse click *)
       | Event ((LTerm_event.Mouse m) as ev) when LTerm_mouse.(m.button=Button1) -> begin
-          let picked = pick LTerm_mouse.(coord m) (toplevel :> t) in
+          let current_layer = List.hd !layers in
+          let picked = pick LTerm_mouse.(coord m) (current_layer :> t) in
           match picked with
           | Some _ -> (* move focus and send it the event *)
-            toplevel#move_focus_to picked;
+            current_layer#move_focus_to picked;
             !(List.hd !focuses)#send_event ev;
             loop ()
           | None -> (* nothing got focus, so drop the event *)


### PR DESCRIPTION
The previous code was using toplevel code to determine the widget to
pass the focus to. In the case of modal layers this is incorrect;
instead of toplevel we need to use the current layer to find the widget
to become focused.

Together with #100 this should close #98 