### PR TITLE
Switch from camomile to uu*

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+* Replace Camomile with uu* (Nicolás Ojeda Bär, ZAN DoYe, Thibaut Mattio, Jonah Beckford, #109)
+
 3.2.0 (2022-02-21)
 ------------------
 

--- a/dune-project
+++ b/dune-project
@@ -28,8 +28,6 @@ facilities in console applications.")
  (depends
   (ocaml
    (>= 4.08.0))
-  (camomile
-   (>= 1.0.1))
   (lwt
    (>= 4.2.0))
   lwt_log
@@ -41,5 +39,5 @@ facilities in console applications.")
   react
   (zed
    (and
-    (>= 3.1.0)
-    (< 3.2.0)))))
+    (>= 3.2.0)
+    (< 4.0)))))

--- a/examples/asciiart/asciiart.ml
+++ b/examples/asciiart/asciiart.ml
@@ -58,7 +58,6 @@ let indices img =
 open Lwt
 open LTerm_widget
 open LTerm_geom
-open CamomileLibrary
 
 (* scrollable asciiart widget *)
 class asciiart img = object(self)
@@ -126,19 +125,19 @@ class asciiart img = object(self)
 
   (* adjust scale, which changes the document size *)
   method private scale_event = function
-    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = UChar.of_char 'w' ->
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = Uchar.of_char 'w' ->
       avg_rows := max 1 (!avg_rows - 1);
       vscroll#set_document_size self#document_size.rows;
       self#queue_draw; true
-    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = UChar.of_char 's' ->
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = Uchar.of_char 's' ->
       avg_rows := !avg_rows + 1; 
       vscroll#set_document_size self#document_size.rows;
       self#queue_draw; true
-    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = UChar.of_char 'a' ->
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = Uchar.of_char 'a' ->
       avg_cols := max 1 (!avg_cols - 1); 
       hscroll#set_document_size self#document_size.cols;
       self#queue_draw; true
-    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = UChar.of_char 'd' ->
+    | LTerm_event.Key{LTerm_key.code=LTerm_key.Char c;_} when c = Uchar.of_char 'd' ->
       avg_cols := !avg_cols + 1; 
       hscroll#set_document_size self#document_size.cols;
       self#queue_draw; true

--- a/examples/double_editor.ml
+++ b/examples/double_editor.ml
@@ -14,7 +14,7 @@ let ( >>= ) = Lwt.( >>= )
 let make_key ?(ctrl = false) ?(meta = false) ?(shift = false) c =
   let code =
     match c with
-    | `Char c -> LTerm_key.Char (CamomileLibrary.UChar.of_char c)
+    | `Char c -> LTerm_key.Char (Uchar.of_char c)
     | `Other key -> key in
   { LTerm_key.control = ctrl; meta; shift; code }
 

--- a/examples/editor.ml
+++ b/examples/editor.ml
@@ -7,7 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
 open Lwt
 
 let main () =
@@ -25,9 +24,9 @@ let main () =
   editor#bind
     (let open LTerm_key in
      [ { control = true; meta = false; shift = false
-       ; code = Char (UChar.of_char 'x') }
+       ; code = Char (Uchar.of_char 'x') }
      ; { control = true; meta = false; shift = false
-       ; code = Char (UChar.of_char 'c') }
+       ; code = Char (Uchar.of_char 'c') }
      ])
     [ LTerm_edit.Custom (fun () -> wakeup wakener ()) ];
 

--- a/examples/read_yes_no.ml
+++ b/examples/read_yes_no.ml
@@ -11,7 +11,7 @@ open Lwt
 
 let rec read_char term =
   LTerm.read_event term >>= function
-    | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch; LTerm_key.control = true ; _ } when ch = CamomileLibraryDefault.Camomile.UChar.of_char 'c' ->
+    | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch; LTerm_key.control = true ; _ } when ch = Uchar.of_char 'c' ->
         (* Exit on Ctrl+C *)
         Lwt.fail (Failure "interrupted")
     | LTerm_event.Key { LTerm_key.code = LTerm_key.Char ch ; _ } ->

--- a/examples/shell.ml
+++ b/examples/shell.ml
@@ -9,7 +9,6 @@
 
 (* A mini shell *)
 
-open CamomileLibraryDefault.Camomile
 open React
 open Lwt
 open LTerm_style
@@ -67,7 +66,7 @@ let make_prompt size exit_code time =
     S" >─";
     S(Zed_utf8.make
         (size.cols - 24 - Zed_utf8.length code - Zed_utf8.length path)
-        (UChar.of_int 0x2500));
+        (Uchar.of_int 0x2500));
     S"[ ";
     B_fg(if exit_code = 0 then lwhite else lred); S code; E_fg;
     S" ]─";

--- a/lambda-term.opam
+++ b/lambda-term.opam
@@ -18,13 +18,12 @@ bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08.0"}
-  "camomile" {>= "1.0.1"}
   "lwt" {>= "4.2.0"}
   "lwt_log"
   "lwt_react"
   "mew_vi" {>= "0.5.0" & < "0.6.0"}
   "react"
-  "zed" {>= "3.1.0" & < "3.2.0"}
+  "zed" {>= "3.2.0" & < "4.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name lambda_term)
   (public_name lambda-term)
   (wrapped false)
-  (libraries camomile lwt lwt.unix lwt_react zed lwt_log mew_vi)
+  (libraries lwt lwt.unix lwt_react zed lwt_log mew_vi uucp)
   (flags (:standard -safe-string))
   (synopsis "Cross-platform library for terminal manipulation")
   (c_library_flags (:standard (:include c_library_flags)))

--- a/src/lTerm.mli
+++ b/src/lTerm.mli
@@ -9,8 +9,6 @@
 
 (** Terminal definitions *)
 
-open CamomileLibrary
-
 type t
   (** Type of terminals. *)
 
@@ -22,8 +20,6 @@ exception No_such_encoding of string
 val create :
   ?windows : bool ->
   ?model : string ->
-  ?incoming_encoding : string ->
-  ?outgoing_encoding : string ->
   Lwt_unix.file_descr -> Lwt_io.input_channel ->
   Lwt_unix.file_descr -> Lwt_io.output_channel -> t Lwt.t
   (** [create ?windows ?model ?incoming_encoding ?outgoing_encoding
@@ -284,11 +280,11 @@ val context_oc : context -> Lwt_io.output_channel
       this channel cannot be used after {!with_context} has
       terminated. *)
 
-val encode_string : t -> Zed_utf8.t -> string
+val encode_string : Zed_utf8.t -> string
   (** [encode_string term str] encodes an UTF-8 string using the
       terminal encoding. *)
 
-val encode_char : t -> UChar.t -> string
+val encode_char : Uchar.t -> string
   (** [encode_char term ch] encodes an unicode character using the
       terminal encoding. *)
 

--- a/src/lTerm_buttons_impl.ml
+++ b/src/lTerm_buttons_impl.ml
@@ -8,7 +8,6 @@
  *)
 
 module Make (LiteralIntf: LiteralIntf.Type) = struct
-  open CamomileLibraryDefault.Camomile
   open LTerm_geom
   open LTerm_key
   open LTerm_mouse
@@ -18,7 +17,7 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
 
   class t = LTerm_widget_base_impl.t
 
-  let space = Char(UChar.of_char ' ')
+  let space = Char(Uchar.of_char ' ')
 
   class button ?brackets initial_label =
     let (bl, br)=

--- a/src/lTerm_draw.ml
+++ b/src/lTerm_draw.ml
@@ -8,7 +8,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
 open LTerm_geom
 open Result
 
@@ -427,7 +426,7 @@ type connection =
 type piece = { top : connection; bottom : connection; left : connection; right : connection }
 
 let piece_of_char char =
-  match UChar.code char with
+  match Uchar.to_int char with
     | 0x2500 -> Some { top = Blank; bottom = Blank; left = Light; right = Light }
     | 0x2501 -> Some { top = Blank; bottom = Blank; left = Heavy; right = Heavy }
     | 0x2502 -> Some { top = Light; bottom = Light; left = Blank; right = Blank }
@@ -511,87 +510,87 @@ let piece_of_char char =
     | _ -> None
 
 let char_of_piece = function
-  | { top = Blank; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x0020
-  | { top = Blank; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2500
-  | { top = Blank; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x2501
-  | { top = Light; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x2502
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x2503
-  | { top = Blank; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x250c
-  | { top = Blank; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x250d
-  | { top = Blank; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x250e
-  | { top = Blank; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x250f
-  | { top = Blank; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2510
-  | { top = Blank; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2511
-  | { top = Blank; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2512
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x2513
-  | { top = Light; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2514
-  | { top = Light; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x2515
-  | { top = Heavy; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2516
-  | { top = Heavy; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x2517
-  | { top = Light; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x2518
-  | { top = Light; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x2519
-  | { top = Heavy; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x251a
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x251b
-  | { top = Light; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x251c
-  | { top = Light; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x251d
-  | { top = Heavy; bottom = Light; left = Blank; right = Light } -> UChar.of_int 0x251e
-  | { top = Light; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x251f
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Light } -> UChar.of_int 0x2520
-  | { top = Heavy; bottom = Light; left = Blank; right = Heavy } -> UChar.of_int 0x2521
-  | { top = Light; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x2522
-  | { top = Heavy; bottom = Heavy; left = Blank; right = Heavy } -> UChar.of_int 0x2523
-  | { top = Light; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2524
-  | { top = Light; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2525
-  | { top = Heavy; bottom = Light; left = Light; right = Blank } -> UChar.of_int 0x2526
-  | { top = Light; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2527
-  | { top = Heavy; bottom = Heavy; left = Light; right = Blank } -> UChar.of_int 0x2528
-  | { top = Heavy; bottom = Light; left = Heavy; right = Blank } -> UChar.of_int 0x2529
-  | { top = Light; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x252a
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Blank } -> UChar.of_int 0x252b
-  | { top = Blank; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x252c
-  | { top = Blank; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x252d
-  | { top = Blank; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x252e
-  | { top = Blank; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x252f
-  | { top = Blank; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2530
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2531
-  | { top = Blank; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x2532
-  | { top = Blank; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x2533
-  | { top = Light; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2534
-  | { top = Light; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x2535
-  | { top = Light; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x2536
-  | { top = Light; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x2537
-  | { top = Heavy; bottom = Blank; left = Light; right = Light } -> UChar.of_int 0x2538
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x2539
-  | { top = Heavy; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x253a
-  | { top = Heavy; bottom = Blank; left = Heavy; right = Heavy } -> UChar.of_int 0x253b
-  | { top = Light; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x253c
-  | { top = Light; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x253d
-  | { top = Light; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x253e
-  | { top = Light; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x253f
-  | { top = Heavy; bottom = Light; left = Light; right = Light } -> UChar.of_int 0x2540
-  | { top = Light; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2541
-  | { top = Heavy; bottom = Heavy; left = Light; right = Light } -> UChar.of_int 0x2542
-  | { top = Heavy; bottom = Light; left = Heavy; right = Light } -> UChar.of_int 0x2543
-  | { top = Heavy; bottom = Light; left = Light; right = Heavy } -> UChar.of_int 0x2544
-  | { top = Light; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2545
-  | { top = Light; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x2546
-  | { top = Heavy; bottom = Light; left = Heavy; right = Heavy } -> UChar.of_int 0x2547
-  | { top = Light; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x2548
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Light } -> UChar.of_int 0x2549
-  | { top = Heavy; bottom = Heavy; left = Light; right = Heavy } -> UChar.of_int 0x254a
-  | { top = Heavy; bottom = Heavy; left = Heavy; right = Heavy } -> UChar.of_int 0x254b
-  | { top = Blank; bottom = Blank; left = Light; right = Blank } -> UChar.of_int 0x2574
-  | { top = Light; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x2575
-  | { top = Blank; bottom = Blank; left = Blank; right = Light } -> UChar.of_int 0x2576
-  | { top = Blank; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x2577
-  | { top = Blank; bottom = Blank; left = Heavy; right = Blank } -> UChar.of_int 0x2578
-  | { top = Heavy; bottom = Blank; left = Blank; right = Blank } -> UChar.of_int 0x2579
-  | { top = Blank; bottom = Blank; left = Blank; right = Heavy } -> UChar.of_int 0x257a
-  | { top = Blank; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x257b
-  | { top = Blank; bottom = Blank; left = Light; right = Heavy } -> UChar.of_int 0x257c
-  | { top = Light; bottom = Heavy; left = Blank; right = Blank } -> UChar.of_int 0x257d
-  | { top = Blank; bottom = Blank; left = Heavy; right = Light } -> UChar.of_int 0x257e
-  | { top = Heavy; bottom = Light; left = Blank; right = Blank } -> UChar.of_int 0x257f
+  | { top = Blank; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x0020
+  | { top = Blank; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2500
+  | { top = Blank; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x2501
+  | { top = Light; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x2502
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x2503
+  | { top = Blank; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x250c
+  | { top = Blank; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x250d
+  | { top = Blank; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x250e
+  | { top = Blank; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x250f
+  | { top = Blank; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2510
+  | { top = Blank; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2511
+  | { top = Blank; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2512
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x2513
+  | { top = Light; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2514
+  | { top = Light; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x2515
+  | { top = Heavy; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2516
+  | { top = Heavy; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x2517
+  | { top = Light; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x2518
+  | { top = Light; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x2519
+  | { top = Heavy; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x251a
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x251b
+  | { top = Light; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x251c
+  | { top = Light; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x251d
+  | { top = Heavy; bottom = Light; left = Blank; right = Light } -> Uchar.of_int 0x251e
+  | { top = Light; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x251f
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Light } -> Uchar.of_int 0x2520
+  | { top = Heavy; bottom = Light; left = Blank; right = Heavy } -> Uchar.of_int 0x2521
+  | { top = Light; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x2522
+  | { top = Heavy; bottom = Heavy; left = Blank; right = Heavy } -> Uchar.of_int 0x2523
+  | { top = Light; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2524
+  | { top = Light; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2525
+  | { top = Heavy; bottom = Light; left = Light; right = Blank } -> Uchar.of_int 0x2526
+  | { top = Light; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2527
+  | { top = Heavy; bottom = Heavy; left = Light; right = Blank } -> Uchar.of_int 0x2528
+  | { top = Heavy; bottom = Light; left = Heavy; right = Blank } -> Uchar.of_int 0x2529
+  | { top = Light; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x252a
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Blank } -> Uchar.of_int 0x252b
+  | { top = Blank; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x252c
+  | { top = Blank; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x252d
+  | { top = Blank; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x252e
+  | { top = Blank; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x252f
+  | { top = Blank; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2530
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2531
+  | { top = Blank; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x2532
+  | { top = Blank; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x2533
+  | { top = Light; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2534
+  | { top = Light; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x2535
+  | { top = Light; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x2536
+  | { top = Light; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x2537
+  | { top = Heavy; bottom = Blank; left = Light; right = Light } -> Uchar.of_int 0x2538
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x2539
+  | { top = Heavy; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x253a
+  | { top = Heavy; bottom = Blank; left = Heavy; right = Heavy } -> Uchar.of_int 0x253b
+  | { top = Light; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x253c
+  | { top = Light; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x253d
+  | { top = Light; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x253e
+  | { top = Light; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x253f
+  | { top = Heavy; bottom = Light; left = Light; right = Light } -> Uchar.of_int 0x2540
+  | { top = Light; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2541
+  | { top = Heavy; bottom = Heavy; left = Light; right = Light } -> Uchar.of_int 0x2542
+  | { top = Heavy; bottom = Light; left = Heavy; right = Light } -> Uchar.of_int 0x2543
+  | { top = Heavy; bottom = Light; left = Light; right = Heavy } -> Uchar.of_int 0x2544
+  | { top = Light; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2545
+  | { top = Light; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x2546
+  | { top = Heavy; bottom = Light; left = Heavy; right = Heavy } -> Uchar.of_int 0x2547
+  | { top = Light; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x2548
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Light } -> Uchar.of_int 0x2549
+  | { top = Heavy; bottom = Heavy; left = Light; right = Heavy } -> Uchar.of_int 0x254a
+  | { top = Heavy; bottom = Heavy; left = Heavy; right = Heavy } -> Uchar.of_int 0x254b
+  | { top = Blank; bottom = Blank; left = Light; right = Blank } -> Uchar.of_int 0x2574
+  | { top = Light; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x2575
+  | { top = Blank; bottom = Blank; left = Blank; right = Light } -> Uchar.of_int 0x2576
+  | { top = Blank; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x2577
+  | { top = Blank; bottom = Blank; left = Heavy; right = Blank } -> Uchar.of_int 0x2578
+  | { top = Heavy; bottom = Blank; left = Blank; right = Blank } -> Uchar.of_int 0x2579
+  | { top = Blank; bottom = Blank; left = Blank; right = Heavy } -> Uchar.of_int 0x257a
+  | { top = Blank; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x257b
+  | { top = Blank; bottom = Blank; left = Light; right = Heavy } -> Uchar.of_int 0x257c
+  | { top = Light; bottom = Heavy; left = Blank; right = Blank } -> Uchar.of_int 0x257d
+  | { top = Blank; bottom = Blank; left = Heavy; right = Light } -> Uchar.of_int 0x257e
+  | { top = Heavy; bottom = Light; left = Blank; right = Blank } -> Uchar.of_int 0x257f
 
 let piece_of_point point=
   match !point with

--- a/src/lTerm_edit.ml
+++ b/src/lTerm_edit.ml
@@ -9,7 +9,6 @@
 
 let pervasives_compare= compare
 
-open CamomileLibraryDefault.Camomile
 open Zed_edit
 open LTerm_key
 open LTerm_geom
@@ -108,24 +107,24 @@ let () =
   bind [{ control = false; meta = false; shift = false; code = Insert }] [Zed Switch_erase_mode];
   bind [{ control = false; meta = false; shift = false; code = Delete }] [Zed Delete_next_char];
   bind [{ control = false; meta = false; shift = false; code = Enter }] [Zed Newline];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char ' ') }] [Zed Set_mark];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'a') }] [Zed Goto_bol];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'e') }] [Zed Goto_eol];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'd') }] [Zed Delete_next_char];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'h') }] [Zed Delete_prev_char];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') }] [Zed Kill_next_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'u') }] [Zed Kill_prev_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'n') }] [Zed Next_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'p') }] [Zed Prev_line];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'w') }] [Zed Kill];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'y') }] [Zed Yank];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char ' ') }] [Zed Set_mark];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'a') }] [Zed Goto_bol];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'e') }] [Zed Goto_eol];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'd') }] [Zed Delete_next_char];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'h') }] [Zed Delete_prev_char];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') }] [Zed Kill_next_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'u') }] [Zed Kill_prev_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'n') }] [Zed Next_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'p') }] [Zed Prev_line];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'w') }] [Zed Kill];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'y') }] [Zed Yank];
   bind [{ control = false; meta = false; shift = false; code = Backspace }] [Zed Delete_prev_char];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'w') }] [Zed Copy];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'c') }] [Zed Capitalize_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'l') }] [Zed Lowercase_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'u') }] [Zed Uppercase_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'b') }] [Zed Prev_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'f') }] [Zed Next_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'w') }] [Zed Copy];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'c') }] [Zed Capitalize_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'l') }] [Zed Lowercase_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'u') }] [Zed Uppercase_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'b') }] [Zed Prev_word];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'f') }] [Zed Next_word];
   bind [{ control = false; meta = true; shift = false; code = Right }] [Zed Next_word];
   bind [{ control = false; meta = true; shift = false; code = Left }] [Zed Prev_word];
   bind [{ control = true; meta = false; shift = false; code = Right }] [Zed Next_word];
@@ -133,21 +132,21 @@ let () =
   bind [{ control = false; meta = true; shift = false; code = Backspace }] [Zed Kill_prev_word];
   bind [{ control = false; meta = true; shift = false; code = Delete }] [Zed Kill_prev_word];
   bind [{ control = true; meta = false; shift = false; code = Delete }] [Zed Kill_next_word];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'd') }] [Zed Kill_next_word];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char '_') }] [Zed Undo];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char '(') }] [Start_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char ')') }] [Stop_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(UChar.of_char 'e') }] [Play_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'g') }] [Cancel_macro];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'd') }] [Zed Kill_next_word];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char '_') }] [Zed Undo];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char '(') }] [Start_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char ')') }] [Stop_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }; { control = false; meta = false; shift = false; code = Char(Uchar.of_char 'e') }] [Play_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'g') }] [Cancel_macro];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
         { control = false; meta = false; shift = false; code = Tab }] [Insert_macro_counter];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'a') }] [Add_macro_counter];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'k') };
-        { control = true; meta = false; shift = false; code = Char(UChar.of_char 'c') }] [Set_macro_counter]
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'a') }] [Add_macro_counter];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'k') };
+        { control = true; meta = false; shift = false; code = Char(Uchar.of_char 'c') }] [Set_macro_counter]
 
 (* +-----------------------------------------------------------------+
    | Widgets                                                         |
@@ -156,20 +155,17 @@ let () =
 let clipboard = Zed_edit.new_clipboard ()
 let macro = Zed_macro.create []
 
-let regexp_word =
-  let set = UCharInfo.load_property_set `Alphabetic in
-  let set = List.fold_left (fun set ch -> USet.add (UChar.of_char ch) set) set ['0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9'] in
-  Zed_re.Core.compile (`Repn(`Set set, 1, None))
-
 let dummy_engine = Zed_edit.create ()
 let dummy_cursor = Zed_edit.new_cursor dummy_engine
 let dummy_context = Zed_edit.context dummy_engine dummy_cursor
-let newline = Zed_char.unsafe_of_uChar (UChar.of_char '\n')
+let newline = Zed_char.unsafe_of_uChar (Uchar.of_char '\n')
 
 class scrollable = object
   inherit LTerm_widget.scrollable
   method! calculate_range page_size document_size = (document_size - page_size/2)
 end
+
+let default_match_word _ _ = None
 
 class edit ?(clipboard = clipboard) ?(macro = macro) ?(size = { cols = 1; rows = 1 }) () =
   let locale, set_locale = S.create None in
@@ -205,7 +201,7 @@ object(self)
     current_line_style <- LTerm_resources.get_style (rc ^ ".current-line") resources
 
   method editable _pos _len = true
-  method match_word text pos = match_by_regexp_core regexp_word text pos
+  method match_word = default_match_word
   method locale = S.value locale
   method set_locale locale = set_locale locale
 
@@ -263,7 +259,7 @@ object(self)
     engine <- (
       Zed_edit.create
         ~editable:(fun pos len -> self#editable pos len)
-        ~match_word:(fun text pos -> self#match_word text pos)
+        ?match_word:(if self # match_word == default_match_word then None else Some self # match_word)
         ~clipboard
         ~locale
         ()

--- a/src/lTerm_history.ml
+++ b/src/lTerm_history.ml
@@ -7,8 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
-
 let return, (>>=) = Lwt.return, Lwt.(>>=)
 
 (* A node contains an entry of the history. *)
@@ -86,9 +84,7 @@ let create ?(max_size=max_int) ?(max_entries=max_int) init =
     cache = None;
   }
 
-let spaces = UCharInfo.load_property_tbl `White_Space
-
-let is_space_uChar ch = UCharTbl.Bool.get spaces ch
+let is_space_uChar ch = Uucp.White.is_white_space ch
 let is_space ch = Zed_char.for_all is_space_uChar ch
 let is_empty str = Zed_string.for_all is_space str
 

--- a/src/lTerm_inputrc.mll
+++ b/src/lTerm_inputrc.mll
@@ -8,7 +8,6 @@
  *)
 
 {
-  open CamomileLibraryDefault.Camomile
   open LTerm_key
 
   let return, (>>=) = Lwt.return, Lwt.(>>=)
@@ -285,7 +284,7 @@ and sequence key seq = parse
       }
   | [ 'a'-'z' 'A'-'Z' '0'-'9' '_' '(' ')' '[' ']' '{' '}' '~' '&' '$' '*' '%' '!' '?' ',' ';' '/' '\\' '.' '@' '=' '+' '-' '^' ] as ch (blank+ | ':' as sep)
       {
-        let seq = { key with code = Char(UChar.of_char ch) } :: seq in
+        let seq = { key with code = Char(Uchar.of_char ch) } :: seq in
         if sep = ":" then
           actions (List.rev seq) [] lexbuf
         else
@@ -303,7 +302,7 @@ and sequence key seq = parse
                | 'a' .. 'f' -> Char.code ch - Char.code 'a' + 10
                | _ -> assert false)
         done;
-        match try Some (UChar.of_int !code) with _ -> None with
+        match try Some (Uchar.of_int !code) with _ -> None with
           | Some ch ->
               let seq = { key with code = Char ch } :: seq in
               if sep = ":" then

--- a/src/lTerm_key.ml
+++ b/src/lTerm_key.ml
@@ -7,10 +7,15 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
+(* little hack to maintain 4.02.3 compat with warnings *)
+module String = struct
+  [@@@ocaml.warning "-3-32"]
+  let lowercase_ascii =  StringLabels.lowercase
+  include String
+end
 
 type code =
-  | Char of UChar.t
+  | Char of Uchar.t
   | Enter
   | Escape
   | Tab
@@ -52,7 +57,7 @@ let meta key = key.meta
 let code key = key.code
 
 let string_of_code = function
-  | Char ch -> Printf.sprintf "Char 0x%02x" (UChar.code ch)
+  | Char ch -> Printf.sprintf "Char 0x%02x" (Uchar.to_int ch)
   | Enter -> "Enter"
   | Escape -> "Escape"
   | Tab -> "Tab"
@@ -90,7 +95,7 @@ let to_string_compact key =
   if key.shift then Buffer.add_string buffer "S-";
   (match key.code with
      | Char ch ->
-         let code = UChar.code ch in
+         let code = Uchar.to_int ch in
          if code <= 255 then
            match Char.chr code with
              | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9'

--- a/src/lTerm_key.mli
+++ b/src/lTerm_key.mli
@@ -9,11 +9,9 @@
 
 (** Keys *)
 
-open CamomileLibrary
-
 (** Type of key code. *)
 type code =
-  | Char of UChar.t
+  | Char of Uchar.t
       (** A unicode character. *)
   | Enter
   | Escape

--- a/src/lTerm_read_line.ml
+++ b/src/lTerm_read_line.ml
@@ -7,7 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_geom
 open LTerm_style
@@ -77,18 +76,18 @@ let () =
   bind [{ control = false; meta = false; shift = false; code = Down }] [History_next];
   bind [{ control = false; meta = false; shift = false; code = Tab }] [Complete];
   bind [{ control = false; meta = false; shift = false; code = Enter }] [Accept];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'b') }] [Edit (LTerm_edit.Zed Zed_edit.Prev_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'f') }] [Edit (LTerm_edit.Zed Zed_edit.Next_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'h') }] [Edit (LTerm_edit.Zed Zed_edit.Delete_prev_char)];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'c') }] [Break];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'z') }] [Suspend];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'm') }] [Accept];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'l') }] [Clear_screen];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'r') }] [Prev_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 's') }] [Next_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'd') }] [Interrupt_or_delete_next_char];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'p') }] [History_prev];
-  bind [{ control = false; meta = true; shift = false; code = Char(UChar.of_char 'n') }] [History_next];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'b') }] [Edit (LTerm_edit.Zed Zed_edit.Prev_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'f') }] [Edit (LTerm_edit.Zed Zed_edit.Next_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'h') }] [Edit (LTerm_edit.Zed Zed_edit.Delete_prev_char)];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'c') }] [Break];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'z') }] [Suspend];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'm') }] [Accept];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'l') }] [Clear_screen];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'r') }] [Prev_search];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 's') }] [Next_search];
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'd') }] [Interrupt_or_delete_next_char];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'p') }] [History_prev];
+  bind [{ control = false; meta = true; shift = false; code = Char(Uchar.of_char 'n') }] [History_next];
   bind [{ control = false; meta = true; shift = false; code = Left }] [Complete_bar_prev];
   bind [{ control = false; meta = true; shift = false; code = Right }] [Complete_bar_next];
   bind [{ control = false; meta = true; shift = false; code = Home }] [Complete_bar_first];
@@ -97,8 +96,8 @@ let () =
   bind [{ control = false; meta = true; shift = false; code = Down }] [Complete_bar];
   bind [{ control = false; meta = true; shift = false; code = Enter }] [Edit (LTerm_edit.Zed Zed_edit.Newline)];
   bind [{ control = false; meta = false; shift = false; code = Escape }] [Cancel_search];
-  bind [{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'x') }
-       ;{ control = true; meta = false; shift = false; code = Char(UChar.of_char 'e') }]
+  bind [{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'x') }
+       ;{ control = true; meta = false; shift = false; code = Char(Uchar.of_char 'e') }]
     [Edit_with_external_editor]
 
 (* +-----------------------------------------------------------------+
@@ -569,7 +568,7 @@ end
 class virtual ['a] abstract = object
   method virtual eval : 'a
   method virtual send_action : action -> unit
-  method virtual insert : UChar.t -> unit
+  method virtual insert : Uchar.t -> unit
   method virtual edit : unit Zed_edit.t
   method virtual context : unit Zed_edit.context
   method virtual clipboard : Zed_edit.clipboard
@@ -641,7 +640,7 @@ end
    | Running in a terminal                                           |
    +-----------------------------------------------------------------+ *)
 
-let newline_uChar = UChar.of_char '\n'
+let newline_uChar = Uchar.of_char '\n'
 let newline = Zed_char.unsafe_of_uChar @@ newline_uChar
 let vline = LTerm_draw.({ top = Light; bottom = Light; left = Blank; right = Blank })
 let reverse_style = { LTerm_style.none with LTerm_style.reverse = Some true }
@@ -1110,7 +1109,7 @@ object(self)
                 | { control = false; meta = false; shift = false; code = Char ch } ->
                     Zed_macro.add self#macro (Edit (LTerm_edit.Zed (Zed_edit.Insert (Zed_char.unsafe_of_uChar ch))));
                     self#insert ch
-                | { code = Char ch; _ } when LTerm.windows term && UChar.code ch >= 32 ->
+                | { code = Char ch; _ } when LTerm.windows term && Uchar.to_int ch >= 32 ->
                     (* Windows reports Shift+A for A, ... *)
                     Zed_macro.add self#macro (Edit (LTerm_edit.Zed (Zed_edit.Insert (Zed_char.unsafe_of_uChar ch))));
                     self#insert ch

--- a/src/lTerm_read_line.mli
+++ b/src/lTerm_read_line.mli
@@ -12,7 +12,6 @@
 (** For a complete example of usage of this module, look at the shell
     example (examples/shell.ml) distributed with Lambda-Term. *)
 
-open CamomileLibrary
 open React
 
 exception Interrupt
@@ -144,7 +143,7 @@ class virtual ['a] engine : ?history : history -> ?clipboard : Zed_edit.clipboar
 
   (** {6 Actions} *)
 
-  method insert : UChar.t -> unit
+  method insert : Uchar.t -> unit
     (** Inserts the given character. Note that is it also possible to
         manipulate directly the edition context. *)
 
@@ -224,7 +223,7 @@ end
 class virtual ['a] abstract : object
   method virtual eval : 'a
   method virtual send_action : action -> unit
-  method virtual insert : UChar.t -> unit
+  method virtual insert : Uchar.t -> unit
   method virtual edit : unit Zed_edit.t
   method virtual context : unit Zed_edit.context
   method virtual clipboard : Zed_edit.clipboard

--- a/src/lTerm_scroll_impl.ml
+++ b/src/lTerm_scroll_impl.ml
@@ -257,7 +257,7 @@ class virtual scrollbar
     let { cols; rows } = size_of_rect rect in
     if cols=1 || rows=1 || bar_style=`filled then
       let x =
-        CamomileLibrary.UChar.of_int @@
+        Uchar.of_int @@
           if bar_style=`filled then 0x2588
           else if cols=1 then vbar
           else hbar

--- a/src/lTerm_text_impl.ml
+++ b/src/lTerm_text_impl.ml
@@ -8,7 +8,6 @@
  *)
 
 module Make (LiteralIntf: LiteralIntf.Type) = struct
-  open CamomileLibraryDefault.Camomile
   open LTerm_style
   open Result
 
@@ -40,9 +39,9 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
 
   let uchar_of_hex x =
     if x < 10 then
-      UChar.of_int (Char.code '0' + x)
+      Uchar.of_int (Char.code '0' + x)
     else
-      UChar.of_int (Char.code 'a' + x - 10)
+      Uchar.of_int (Char.code 'a' + x - 10)
 
   let of_string_maybe_invalid str=
     let len= Zed_string.length str in
@@ -58,7 +57,7 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
             (ofs, idx + 1)
           with
             Zed_utf8.Invalid _->
-            let code= UChar.int_of (Zed_char.core (Zed_string.extract str ofs)) in
+            let code= Uchar.to_int (Zed_char.core (Zed_string.extract str ofs)) in
             Array.unsafe_set arr (idx + 0)
               (Zed_char.unsafe_of_char '\\', LTerm_style.none);
             Array.unsafe_set arr (idx + 1)

--- a/src/lTerm_unix.mli
+++ b/src/lTerm_unix.mli
@@ -9,8 +9,6 @@
 
 (** Unix specific functions *)
 
-open CamomileLibraryDefault.Camomile
-
 val sigwinch : int option
   (** The number of the signal used to indicate that the terminal size
       have changed. It is [None] on windows. *)
@@ -18,7 +16,7 @@ val sigwinch : int option
 val system_encoding : string
   (** The encoding used by the system. *)
 
-val parse_event : ?escape_time : float -> CharEncoding.t -> char Lwt_stream.t -> LTerm_event.t Lwt.t
+val parse_event : ?escape_time : float -> char Lwt_stream.t -> LTerm_event.t Lwt.t
   (** [parse_event encoding stream] parses one event from the given
       input stream. [encoding] is the character encoding used to
       decode non-ascii characters. It must be a converter from the

--- a/src/lTerm_vi.ml
+++ b/src/lTerm_vi.ml
@@ -144,13 +144,11 @@ module Query = struct
     else
       max 0 (stop - 1)
 
-  open CamomileLibraryDefault.Camomile
-
   let get_category ?(nl_as_sp=false) uchar=
     if uchar = Zed_utf8.extract "\n" 0 && nl_as_sp then
       `Zs
     else
-      UCharInfo.general_category uchar
+      Uucp.Gc.general_category uchar
 
   let get_boundary multi_line ctx=
     let edit= Zed_edit.edit ctx in

--- a/src/lTerm_vi.mli
+++ b/src/lTerm_vi.mli
@@ -41,8 +41,8 @@ module Query :
     val line_LastChar : ?newline:bool -> int -> 'a Zed_edit.context -> int
     val get_category :
       ?nl_as_sp:bool ->
-      CamomileLibrary.UChar.t ->
-      CamomileLibraryDefault.Camomile.UCharInfo.general_category_type
+      Uchar.t ->
+      Uucp.Gc.t
     val get_boundary : bool -> 'a Zed_edit.context -> int * int
     val is_space : [> `Cc | `Mn | `Zl | `Zp | `Zs ] -> bool
     val is_not_space : [> `Cc | `Mn | `Zl | `Zp | `Zs ] -> bool
@@ -52,15 +52,11 @@ module Query :
       [> `Cc | `Mn | `Zl | `Zp | `Zs ] -> bool
     val next_category :
       ?nl_as_sp:bool ->
-      ?is_equal:(CamomileLibraryDefault.Camomile.UCharInfo.general_category_type ->
-                CamomileLibraryDefault.Camomile.UCharInfo.general_category_type ->
-                bool) ->
+      ?is_equal:(Uucp.Gc.t -> Uucp.Gc.t -> bool) ->
       pos:int -> stop:int -> Zed_rope.t -> int
     val prev_category :
       ?nl_as_sp:bool ->
-      ?is_equal:(CamomileLibraryDefault.Camomile.UCharInfo.general_category_type ->
-                CamomileLibraryDefault.Camomile.UCharInfo.general_category_type ->
-                bool) ->
+      ?is_equal:(Uucp.Gc.t -> Uucp.Gc.t -> bool) ->
       pos:int -> start:int -> Zed_rope.t -> int
     val goto_line : 'a Zed_edit.context -> int -> int
     val next_line : 'a Zed_edit.context -> int -> int

--- a/src/lTerm_windows.ml
+++ b/src/lTerm_windows.ml
@@ -7,8 +7,6 @@
  * This file is a part of Lambda-Term.
  *)
 
-open CamomileLibraryDefault.Camomile
-
 let (>|=) = Lwt.(>|=)
 
 external get_acp : unit -> int = "lt_windows_get_acp"
@@ -25,38 +23,38 @@ type input =
 external read_console_input_job : Unix.file_descr -> input Lwt_unix.job = "lt_windows_read_console_input_job"
 
 let controls = [|
-  UChar.of_char ' ';
-  UChar.of_char 'a';
-  UChar.of_char 'b';
-  UChar.of_char 'c';
-  UChar.of_char 'd';
-  UChar.of_char 'e';
-  UChar.of_char 'f';
-  UChar.of_char 'g';
-  UChar.of_char 'h';
-  UChar.of_char 'i';
-  UChar.of_char 'j';
-  UChar.of_char 'k';
-  UChar.of_char 'l';
-  UChar.of_char 'm';
-  UChar.of_char 'n';
-  UChar.of_char 'o';
-  UChar.of_char 'p';
-  UChar.of_char 'q';
-  UChar.of_char 'r';
-  UChar.of_char 's';
-  UChar.of_char 't';
-  UChar.of_char 'u';
-  UChar.of_char 'v';
-  UChar.of_char 'w';
-  UChar.of_char 'x';
-  UChar.of_char 'y';
-  UChar.of_char 'z';
-  UChar.of_char '[';
-  UChar.of_char '\\';
-  UChar.of_char ']';
-  UChar.of_char '^';
-  UChar.of_char '_';
+  Uchar.of_char ' ';
+  Uchar.of_char 'a';
+  Uchar.of_char 'b';
+  Uchar.of_char 'c';
+  Uchar.of_char 'd';
+  Uchar.of_char 'e';
+  Uchar.of_char 'f';
+  Uchar.of_char 'g';
+  Uchar.of_char 'h';
+  Uchar.of_char 'i';
+  Uchar.of_char 'j';
+  Uchar.of_char 'k';
+  Uchar.of_char 'l';
+  Uchar.of_char 'm';
+  Uchar.of_char 'n';
+  Uchar.of_char 'o';
+  Uchar.of_char 'p';
+  Uchar.of_char 'q';
+  Uchar.of_char 'r';
+  Uchar.of_char 's';
+  Uchar.of_char 't';
+  Uchar.of_char 'u';
+  Uchar.of_char 'v';
+  Uchar.of_char 'w';
+  Uchar.of_char 'x';
+  Uchar.of_char 'y';
+  Uchar.of_char 'z';
+  Uchar.of_char '[';
+  Uchar.of_char '\\';
+  Uchar.of_char ']';
+  Uchar.of_char '^';
+  Uchar.of_char '_';
 |]
 
 let read_console_input fd =
@@ -64,8 +62,8 @@ let read_console_input fd =
   Lwt_unix.run_job ?async_method:None
    (read_console_input_job (Lwt_unix.unix_file_descr fd))
   >|= function
-  | Key({ LTerm_key.code = LTerm_key.Char ch ; _ } as key) when UChar.code ch < 32 ->
-    Key { key with LTerm_key.code = LTerm_key.Char controls.(UChar.code ch) }
+  | Key({ LTerm_key.code = LTerm_key.Char ch ; _ } as key) when Uchar.to_int ch < 32 ->
+    Key { key with LTerm_key.code = LTerm_key.Char controls.(Uchar.to_int ch) }
   | input ->
     input
 
@@ -139,7 +137,7 @@ type char_info = {
 }
 
 type char_info_raw = {
-  cir_char : UChar.t;
+  cir_char : Uchar.t;
   cir_foreground : int;
   cir_background : int;
 }
@@ -169,7 +167,7 @@ let write_console_output fd chars size coord rect =
   let chars= chars_to_raw chars in
   write_console_output (Lwt_unix.unix_file_descr fd) chars size coord rect
 
-external fill_console_output_character : Unix.file_descr -> UChar.t -> int -> LTerm_geom.coord -> int = "lt_windows_fill_console_output_character"
+external fill_console_output_character : Unix.file_descr -> Uchar.t -> int -> LTerm_geom.coord -> int = "lt_windows_fill_console_output_character"
 
 let fill_console_output_character fd char count coord =
   Lwt_unix.check_descriptor fd;

--- a/src/lTerm_windows.mli
+++ b/src/lTerm_windows.mli
@@ -11,8 +11,6 @@
 
 (** All these functions return [Lwt_sys.Not_available] on Unix. *)
 
-open CamomileLibrary
-
 (** {6 Codepage functions} *)
 
 val get_acp : unit -> int
@@ -129,7 +127,7 @@ val write_console_output : Lwt_unix.file_descr -> char_info array array -> LTerm
       matrix of characters with their attributes on the given console
       at given position. *)
 
-val fill_console_output_character : Lwt_unix.file_descr -> UChar.t -> int -> LTerm_geom.coord -> int
+val fill_console_output_character : Lwt_unix.file_descr -> Uchar.t -> int -> LTerm_geom.coord -> int
   (** [fill_console_output_character fd char count coord] writes
       [count] times [char] starting at [coord] on the given
       console. *)

--- a/src/literalIntf.ml
+++ b/src/literalIntf.ml
@@ -1,5 +1,3 @@
-open CamomileLibrary
-
 module type Type =
   sig
     type char_intf
@@ -7,8 +5,8 @@ module type Type =
     val empty_string : unit -> string_intf
     val of_char : Zed_char.t -> char_intf
     val of_string : Zed_string.t -> string_intf
-    val to_char : char_intf -> Zed_char.t option * UChar.t list
-    val to_string : string_intf -> Zed_string.t * UChar.t list
+    val to_char : char_intf -> Zed_char.t option * Uchar.t list
+    val to_string : string_intf -> Zed_string.t * Uchar.t list
     val to_char_exn : char_intf -> Zed_char.t
     val to_string_exn : string_intf -> Zed_string.t
   end
@@ -17,7 +15,7 @@ module Zed : Type
   with type char_intf= Zed_char.t
   and type string_intf= Zed_string.t =
 struct
-  external id : 'a -> 'a = "%identity"
+  let id x = x
   type char_intf= Zed_char.t
   type string_intf= Zed_string.t
 
@@ -34,18 +32,15 @@ module UTF8 : Type
   with type char_intf= Zed_utf8.t
   and type string_intf= Zed_utf8.t =
 struct
-  module Zed_char_UTF8 = Zed_char.US(UTF8)
-  module Zed_string_UTF8 = Zed_string.US(UTF8)
-
   type char_intf= Zed_utf8.t
   type string_intf= Zed_utf8.t
 
   let empty_string ()= ""
   let of_char= Zed_char.to_utf8
   let of_string= Zed_string.to_utf8
-  let to_char= Zed_char_UTF8.to_t
-  let to_string= Zed_string_UTF8.to_t
-  let to_char_exn= Zed_char_UTF8.to_t_exn
-  let to_string_exn= Zed_string.unsafe_of_utf8
+  let to_char x = Zed_char.of_uChars (Zed_utf8.explode x)
+  let to_string x = Zed_string.of_uChars (Zed_utf8.explode x)
+  let to_char_exn x = match to_char x with Some t, _ -> t | _ -> failwith "to_t_exn"
+  let to_string_exn = Zed_string.unsafe_of_utf8
 end
 


### PR DESCRIPTION
This is a follow-up on https://github.com/ocaml-community/zed/pull/46 to remove the camomile dependency and replace it with uu* libraries.

The commit is based on the work of @kandu and @nojb in https://github.com/ocaml-community/lambda-term/compare/master...kandu:lambda-term:uu and additional patches from Diskuv: https://github.com/ocaml-community/lambda-term/commit/faca89a3aafe8301edf0671e775f779212d6578d and https://github.com/ocaml-community/lambda-term/commit/25b5d6417dbcc43f9602007f43990faa00da07ad. cc @jonahbeckford is it ok to include your patches here license-wise? I've added you as a co-author of the commit.

Fixes https://github.com/ocaml-community/lambda-term/issues/93