### PR TITLE
Updated XDG base directory handling

### DIFF
--- a/src/lTerm_resources.ml
+++ b/src/lTerm_resources.ml
@@ -34,12 +34,19 @@ module XDGBD = struct
     try
       Sys.getenv env_var
     with Not_found ->
-      if Sys.win32 then win32_default else unix_default
+      if Sys.win32 then
+        win32_default ()
+      else
+        unix_default
 
-  let cache  = get "XDG_CACHE_HOME"  (home / ".cache")           (home / "Local Settings" / "Cache")
-  let config = get "XDG_CONFIG_HOME" (home / ".config")          (home / "Local Settings")
-  let data   = get "XDG_DATA_HOME"   (home / ".local" / "share") (try Sys.getenv "AppData" with Not_found -> "")
-  let state  = get "XDG_STATE_HOME"  (home / ".local" / "state") (try Sys.getenv "AppData" with Not_found -> "")
+  let cache  = get "XDG_CACHE_HOME"  (home / ".cache") @@ fun () ->
+    try Sys.getenv "LocalAppData" / "Cache" with Not_found -> home / "AppData" / "Local" / "Cache"
+  let config = get "XDG_CONFIG_HOME" (home / ".config") @@ fun () ->
+    try Sys.getenv "AppData" with Not_found -> home / "AppData" / "Roaming"
+  let data   = get "XDG_DATA_HOME"   (home / ".local" / "share") @@ fun () ->
+    try Sys.getenv "AppData" with Not_found -> home / "AppData" / "Roaming"
+  let state  = get "XDG_STATE_HOME"  (home / ".local" / "state") @@ fun () ->
+    try Sys.getenv "LocalAppData" with Not_found -> home / "AppData" / "Local"
 
   let user_dir = function
     | Cache  -> cache

--- a/src/lTerm_resources.ml
+++ b/src/lTerm_resources.ml
@@ -25,7 +25,7 @@ let home =
       else
         ""
 
-type xdg_location = Cache | Config | Data
+type xdg_location = Cache | Config | Data | State
 
 module XDGBD = struct
   let ( / ) = Filename.concat
@@ -39,18 +39,21 @@ module XDGBD = struct
   let cache  = get "XDG_CACHE_HOME"  (home / ".cache")           (home / "Local Settings" / "Cache")
   let config = get "XDG_CONFIG_HOME" (home / ".config")          (home / "Local Settings")
   let data   = get "XDG_DATA_HOME"   (home / ".local" / "share") (try Sys.getenv "AppData" with Not_found -> "")
+  let state  = get "XDG_STATE_HOME"  (home / ".local" / "state") (try Sys.getenv "AppData" with Not_found -> "")
 
   let user_dir = function
     | Cache  -> cache
     | Config -> config
     | Data   -> data
+    | State  -> state
 end
 
 let xdgbd_warning loc file_name =
   let loc_name = match loc with
     | Cache  -> "$XDG_CACHE_HOME"
     | Config -> "$XDG_CONFIG_HOME"
-    | Data   -> "$XDG_DATA_HOME" in
+    | Data   -> "$XDG_DATA_HOME"
+    | State  -> "$XDG_STATE_HOME" in
   Printf.eprintf
     "Warning: it is recommended to move `%s` to `%s`, see:\n%s\n"
     file_name loc_name

--- a/src/lTerm_resources.mli
+++ b/src/lTerm_resources.mli
@@ -65,8 +65,10 @@ val load : string -> t Lwt.t
 val home : string
   (** The home directory. *)
 
-type xdg_location = Cache | Config | Data
-  (** The type for user-specific 'cached', 'configuration' and 'data' files. *)
+type xdg_location = Cache | Config | Data | State
+  (** The type for user-specific 'cached', 'configuration',
+      'data', and 'state' files.
+  *)
 
 val xdgbd_file : loc:xdg_location -> ?legacy_name:string -> string -> string
   (** [xdgbd_file ~loc fn] returns the full file-name for a file [fn] in the


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) has added `XDG_STATE_HOME` to the specification for local application state such as command-line history.
This PR adds support for said directory.

Additionally, the Windows directory paths were updated.
Prior to this commit, Windows paths were using legacy paths.
Lambda-term should use the current Known Folders as described [here](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid).

| Variable | Old Path | New Path | New Fallback |
| --- | --- | --- | --- |
| `cache` | `%USERPROFILE%\Local Settings\Cache` | `%LOCALAPPDATA%\Cache` | `%USERPROFILE%\AppData\Local\Cache`|
| `config` | `%USERPROFILE%\Local Settings` | `%APPDATA%` | `%USERPROFILE%\AppData\Roaming` |
| `data` | `%APPDATA%` (fallback `""`) | `%APPDATA%` | `%USERPROFILE%\AppData\Roaming` |
| `state` | N/A | `%LOCALAPPDATA%` | `%USERPROFILE%\AppData\Local` |