### PR TITLE
Fix of_string_maybe_invalid

### DIFF
--- a/src/lTerm_text_impl.ml
+++ b/src/lTerm_text_impl.ml
@@ -44,36 +44,25 @@ module Make (LiteralIntf: LiteralIntf.Type) = struct
       Uchar.of_int (Char.code 'a' + x - 10)
 
   let of_string_maybe_invalid str=
-    let len= Zed_string.length str in
-    let arr= Array.make len dummy in
-    let rec loop ofs idx=
-      if idx = len then
-        arr
+    let txt zc = (zc, LTerm_style.none) in
+    let rec loop ofs acc =
+      if ofs = 0 then acc
       else begin
-        let ofs, idx=
-          try
-            let chr, ofs= Zed_string.extract_next str ofs in
-            Array.unsafe_set arr idx (chr, LTerm_style.none);
-            (ofs, idx + 1)
-          with
-            Zed_utf8.Invalid _->
-            let code= Uchar.to_int (Zed_char.core (Zed_string.extract str ofs)) in
-            Array.unsafe_set arr (idx + 0)
-              (Zed_char.unsafe_of_char '\\', LTerm_style.none);
-            Array.unsafe_set arr (idx + 1)
-              (Zed_char.unsafe_of_char 'y', LTerm_style.none);
-            Array.unsafe_set arr (idx + 2)
-              (Zed_char.unsafe_of_uChar (uchar_of_hex (code lsr 4))
-              , LTerm_style.none);
-            Array.unsafe_set arr (idx + 3)
-              (Zed_char.unsafe_of_uChar (uchar_of_hex (code land 15))
-              , LTerm_style.none);
-            ofs + 1, idx + 4
-        in
-        loop ofs idx
-      end
-    in
-    loop 0 0
+        try
+          let (zc, ofs') = Zed_string.extract_prev str ofs in
+          loop ofs' (txt zc :: acc)
+        with Invalid_argument _ | Zed_utf8.Invalid _ ->
+          (* extract_prev calls Zed_utf8.unsafe_extract_prev which throws
+             Zed_utf8.Invalid, or can call Uchar.of_int which throws Invalid_argument *)
+          let invalid = Zed_string.sub_ofs ~ofs:(ofs-1) ~len:1 str in
+          let code = Char.code (Zed_string.to_utf8 invalid).[0] in
+          loop (ofs - 1) (txt (Zed_char.unsafe_of_char '\\') ::
+                          txt (Zed_char.unsafe_of_char 'y') ::
+                          txt (Zed_char.unsafe_of_uChar (uchar_of_hex (code lsr 4))) ::
+                          txt (Zed_char.unsafe_of_uChar (uchar_of_hex (code land 15))) ::
+                          acc)
+      end in
+    Array.of_list @@ loop (Zed_string.bytes str) []
 
   let of_utf8_maybe_invalid str=
     let str= Zed_string.unsafe_of_utf8 str in


### PR DESCRIPTION
Previously this code had calls to `Array.unsafe_set` that would use indices beyond the range of the array being manipulated. Thankfully, `Zed_string.length` would throw an exception first.

Trying to allocate the array in advance does not work out if some Zed_chars are being replaced by an escape sequence with four Zed_chars.