### PR TITLE
release 3.3.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+3.3.2 (2023-08-09)
+------------------
+
+* `LTerm_vi`: fix a downward-action issue when act in empty content
+
 3.3.1 (2022-07-04)
 ------------------
 

--- a/src/lTerm_vi.ml
+++ b/src/lTerm_vi.ml
@@ -1,7 +1,7 @@
 (*
  * lTerm_vi.ml
  * ------------
- * Copyright : (c) 2020, ZAN DoYe <zandoye@gmail.com>
+ * Copyright : (c) 2023, ZAN DoYe <zandoye@gmail.com>
  * Licence   : BSD3
  *
  * This file is a part of Lambda-Term.


### PR DESCRIPTION
3.3.2 (2023-08-09)
------------------

* `LTerm_vi`: fix a downward-action issue when act in empty content