### PR TITLE
replace deprecated Lwt_unix.run with recommended Lwt_main.run

### DIFF
--- a/src/lTerm_vi.ml
+++ b/src/lTerm_vi.ml
@@ -10,7 +10,7 @@
 module Concurrent = struct
   module Thread= struct
       include Lwt
-      let run= Lwt_unix.run [@@ocaml.warning "-3"]
+      let run= Lwt_main.run
       let sleep= Lwt_unix.sleep
     end
   module MsgBox= struct


### PR DESCRIPTION
this is in preparation for Lwt.6